### PR TITLE
Run opencode as subprocess to clear banner on exit, reorder table columns for copy-paste

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -98,22 +98,22 @@ List all worktrees and their session status. Local worktrees (all repos under
 concurrently and merged into a single table sorted by most recent activity.
 
 ```
-  UPDATED     CREATED     WORKTREE            REPO                                STATUS    TITLE
-  just now    3h ago      0423T1430-12847     [remote] /home/user/.../acme/api    working   Fix auth handler validation
-  5m ago      1d ago      0423T1600-4419      /Users/user/.../acme/api            idle      Refactor config parser
-  -           2d ago      0421T1100-5531      [remote] /home/user/.../acme/web    -         -
+WORKTREE            STATUS    TITLE                           AGE     ACTIVITY    REPO
+0423T1430-12847     working   Fix auth handler validation     3h ago  just now    [remote] /home/user/.../acme/api
+0423T1600-4419      idle      Refactor config parser          1d ago  5m ago      /Users/user/.../acme/api
+0421T1100-5531      -         -                               2d ago  -           [remote] /home/user/.../acme/web
 ```
 
 Columns:
 
 | Column | Value |
 |--------|-------|
-| UPDATED | When the most recent session in this worktree was last active. |
-| CREATED | When the worktree was created. |
 | WORKTREE | Branch name (equals the worktree directory name). |
-| REPO | Repo root, shortened to `<home>/.../parent/name`. `[remote]` prefix for remote worktrees. |
 | STATUS | `working` (agent generating), `idle` (session exists, agent not generating). |
 | TITLE | Session title, auto-generated from the first prompt. |
+| AGE | When the worktree was created. |
+| ACTIVITY | When the most recent session in this worktree was last active. |
+| REPO | Repo root, shortened to `<home>/.../parent/name`. `[remote]` prefix for remote worktrees. |
 
 `-` in any column means the value is unavailable. A worktree with no session
 shows `-` for UPDATED, STATUS, and TITLE. Attaching to such a worktree creates

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"syscall"
 
@@ -60,8 +61,8 @@ func cmdLocal(args []string) {
 			die("failed to create worktree: %v", err)
 		}
 		fmt.Printf("Created worktree: %s\n", name)
-		fmt.Printf("  resume:\n  wt %s\n", name)
-		if err := execOpencode(wtDir); err != nil {
+		fmt.Printf("wt %s\n", name)
+		if err := runOpencode(wtDir); err != nil {
 			die("%v", err)
 		}
 		return
@@ -74,13 +75,13 @@ func cmdLocal(args []string) {
 		die("worktree %q not found", name)
 	}
 	if !entry.Remote {
-		if err := execOpencode(entry.Dir); err != nil {
+		if err := runOpencode(entry.Dir); err != nil {
 			die("%v", err)
 		}
 	} else {
 		serverURL := opencode.ServerURL()
 		sessionID := opencode.FindLatestSession(serverURL, entry.Dir)
-		if err := execOpencodeAttach(serverURL, entry.Dir, sessionID); err != nil {
+		if err := runOpencodeAttach(serverURL, entry.Dir, sessionID); err != nil {
 			die("%v", err)
 		}
 	}
@@ -119,7 +120,7 @@ func cmdRemote(args []string) {
 			die("failed to create remote worktree: %v", err)
 		}
 		fmt.Printf("Created worktree: %s\n", name)
-		fmt.Printf("  resume:\n  wt %s\n", name)
+		fmt.Printf("wt %s\n", name)
 	} else {
 		name = args[1]
 		wtDir = repo + "/.worktrees/" + name
@@ -128,10 +129,9 @@ func cmdRemote(args []string) {
 		}
 	}
 
-	// Attach: find most recent session, then opencode attach
 	serverURL := opencode.ServerURL()
 	sessionID := opencode.FindLatestSession(serverURL, wtDir)
-	if err := execOpencodeAttach(serverURL, wtDir, sessionID); err != nil {
+	if err := runOpencodeAttach(serverURL, wtDir, sessionID); err != nil {
 		die("%v", err)
 	}
 }
@@ -224,31 +224,55 @@ func die(format string, args ...any) {
 	os.Exit(1)
 }
 
-// execOpencode replaces the current process with opencode in the given directory.
-func execOpencode(dir string) error {
+// runOpencode runs opencode as a subprocess in the given directory, clearing the
+// terminal on exit to remove opencode's startup banner from scrollback.
+func runOpencode(dir string) error {
 	binary, err := exec.LookPath("opencode")
 	if err != nil {
 		return fmt.Errorf("opencode not found in PATH")
 	}
-
 	if err := os.Chdir(dir); err != nil {
 		return fmt.Errorf("cannot cd to %s: %w", dir, err)
 	}
-
-	return syscall.Exec(binary, []string{"opencode"}, os.Environ())
+	return runAndClear(exec.Command(binary))
 }
 
-// execOpencodeAttach replaces the current process with opencode attach.
-func execOpencodeAttach(serverURL, dir, sessionID string) error {
+// runOpencodeAttach runs opencode attach as a subprocess, clearing the terminal
+// on exit to remove opencode's startup banner from scrollback.
+func runOpencodeAttach(serverURL, dir, sessionID string) error {
 	binary, err := exec.LookPath("opencode")
 	if err != nil {
 		return fmt.Errorf("opencode not found in PATH")
 	}
-
-	args := []string{"opencode", "attach", serverURL, "--dir", dir}
+	args := []string{"attach", serverURL, "--dir", dir}
 	if sessionID != "" {
 		args = append(args, "--session", sessionID)
 	}
+	return runAndClear(exec.Command(binary, args...))
+}
 
-	return syscall.Exec(binary, args, os.Environ())
+// runAndClear runs a TUI command as a subprocess, letting it own the terminal.
+// Terminal signals are ignored in the parent so the child handles them.
+// After the child exits, the terminal is cleared to remove pre-TUI output.
+func runAndClear(cmd *exec.Cmd) error {
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Let the child handle all terminal signals; parent just waits.
+	signal.Ignore(syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTSTP)
+
+	err := cmd.Run()
+
+	// Clear screen to wipe opencode's startup banner from scrollback.
+	fmt.Print("\033[2J\033[H")
+
+	if err != nil {
+		// Forward the child's exit code.
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		return err
+	}
+	return nil
 }

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -14,7 +14,7 @@ import (
 func PrintTable(entries []worktree.Entry) {
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 
-	fmt.Fprintf(w, "  UPDATED\tCREATED\tWORKTREE\tREPO\tSTATUS\tTITLE\n")
+	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tAGE\tACTIVITY\tREPO\n")
 
 	now := time.Now()
 	for _, e := range entries {
@@ -26,10 +26,10 @@ func PrintTable(entries []worktree.Entry) {
 		if title == "" {
 			title = "-"
 		}
-		updated := formatAge(e.UpdatedAt, now)
-		created := formatAge(e.CreatedAt, now)
+		age := formatAge(e.CreatedAt, now)
+		activity := formatAge(e.UpdatedAt, now)
 		repo := formatRepo(e.Repo, e.Remote)
-		fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%s\n", updated, created, e.Name, repo, status, title)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, age, activity, repo)
 	}
 
 	w.Flush()


### PR DESCRIPTION
## Summary

- Switch from `syscall.Exec` to `exec.Command` so `wt` survives as a parent process and can clear the terminal after opencode exits, removing the startup banner from scrollback. Ignore terminal signals (SIGINT, SIGQUIT, SIGTSTP) in the parent so the child handles them.
- Reorder `wt ls` columns to `WORKTREE|STATUS|TITLE|AGE|ACTIVITY|REPO` — worktree name first for triple-click copy, repo last as lowest-value column. Remove leading whitespace from all rows.
- Simplify create output to put the resume command on its own unindented line for easy copy-paste.
- Update design doc to reflect new column names and order.