### PR TITLE
Remove screen clear on exit to preserve terminal scrollback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ellistarn/wt
 
 go 1.25.5
+
+require github.com/creack/pty v1.1.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func runOpencode(dir string) error {
 	if err := os.Chdir(dir); err != nil {
 		return fmt.Errorf("cannot cd to %s: %w", dir, err)
 	}
-	return runAndClear(exec.Command(binary))
+	return runTUI(exec.Command(binary))
 }
 
 // runOpencodeAttach runs opencode attach as a subprocess, clearing the terminal
@@ -248,13 +248,13 @@ func runOpencodeAttach(serverURL, dir, sessionID string) error {
 	if sessionID != "" {
 		args = append(args, "--session", sessionID)
 	}
-	return runAndClear(exec.Command(binary, args...))
+	return runTUI(exec.Command(binary, args...))
 }
 
-// runAndClear runs a TUI command as a subprocess, letting it own the terminal.
+// runTUI runs a TUI command as a subprocess, letting it own the terminal.
 // Terminal signals are ignored in the parent so the child handles them.
-// After the child exits, the terminal is cleared to remove pre-TUI output.
-func runAndClear(cmd *exec.Cmd) error {
+// The TUI's alternate screen buffer handles cleanup automatically on exit.
+func runTUI(cmd *exec.Cmd) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -263,9 +263,6 @@ func runAndClear(cmd *exec.Cmd) error {
 	signal.Ignore(syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTSTP)
 
 	err := cmd.Run()
-
-	// Clear screen to wipe opencode's startup banner from scrollback.
-	fmt.Print("\033[2J\033[H")
 
 	if err != nil {
 		// Forward the child's exit code.

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+func TestE2E_NoScreenClearOnExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	if _, err := exec.LookPath("opencode"); err != nil {
+		t.Skip("opencode not installed")
+	}
+
+	// Build wt
+	bin := filepath.Join(t.TempDir(), "wt")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %s\n%s", err, out)
+	}
+
+	// Create temp git repo with an initial commit
+	repo := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "init", repo},
+		{"git", "-C", repo, "config", "user.email", "test@test.com"},
+		{"git", "-C", repo, "config", "user.name", "Test"},
+		{"git", "-C", repo, "commit", "--allow-empty", "-m", "init"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s\n%s", args, err, out)
+		}
+	}
+
+	// Launch wt in a PTY so opencode gets a real terminal
+	cmd := exec.Command(bin)
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty.Start: %v", err)
+	}
+	defer ptmx.Close()
+
+	// Drain PTY output in background
+	var buf bytes.Buffer
+	outputDone := make(chan struct{})
+	go func() {
+		io.Copy(&buf, ptmx)
+		close(outputDone)
+	}()
+
+	// Wait for opencode to initialize, then send Ctrl+C through the PTY
+	time.Sleep(3 * time.Second)
+	if _, err := ptmx.Write([]byte{0x03}); err != nil {
+		t.Fatalf("failed to send Ctrl+C: %v", err)
+	}
+
+	// Wait for wt to exit
+	exitCh := make(chan error, 1)
+	go func() { exitCh <- cmd.Wait() }()
+	select {
+	case <-exitCh:
+	case <-time.After(10 * time.Second):
+		cmd.Process.Kill()
+		t.Fatal("wt did not exit within 10s")
+	}
+	<-outputDone
+
+	// After opencode exits its alternate screen buffer (rmcup), wt must not
+	// write screen-clear escape sequences -- that destroys the user's scrollback.
+	output := buf.Bytes()
+	rmcup := []byte("\033[?1049l")
+	if idx := bytes.LastIndex(output, rmcup); idx >= 0 {
+		after := output[idx+len(rmcup):]
+		if bytes.Contains(after, []byte("\033[2J")) {
+			t.Errorf("screen clear escape found after alt screen exit: %q", after)
+		}
+	} else {
+		t.Log("no alt screen transition detected; opencode may not have started fully")
+	}
+}


### PR DESCRIPTION
## Summary
- `wt` was writing `\033[2J\033[H` (clear screen) after opencode exited, which destroyed the user's terminal scrollback history
- Removed the clear since opencode's alternate screen buffer already restores the main screen on exit
- Added e2e test that launches `wt` → `opencode` in a real PTY, sends Ctrl+C, and verifies no screen-clear escapes appear after the alt screen buffer exits