### PR TITLE
Fix worktree discovery and speed up wt ls (20s -> 3s)

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -108,7 +108,7 @@ Columns:
 
 | Column | Value |
 |--------|-------|
-| WORKTREE | Branch name (equals the worktree directory name). |
+| WORKTREE | Worktree directory name (the stable identifier even if the branch is renamed). |
 | STATUS | `working` (agent generating), `idle` (session exists, agent not generating). |
 | TITLE | Session title, auto-generated from the first prompt. |
 | AGE | When the worktree was created. |

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/ellistarn/wt/pkg/discover"
@@ -182,13 +183,28 @@ func cmdLs(remoteOnly bool) {
 		remoteCh <- nil
 	}
 
-	local := <-localCh
-	remote := <-remoteCh
+	// Discover and enrich in parallel — each side enriches as soon as
+	// its discovery finishes, without waiting for the other.
+	var local, remote []worktree.Entry
+	var wg sync.WaitGroup
 
-	opencode.EnrichLocal(local)
-	if host != "" {
-		opencode.EnrichRemote(host, remote)
-	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		local = <-localCh
+		opencode.EnrichLocal(local)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		remote = <-remoteCh
+		if host != "" {
+			opencode.EnrichRemote(host, remote)
+		}
+	}()
+
+	wg.Wait()
 
 	all := append(local, remote...)
 	worktree.Sort(all)

--- a/pkg/discover/local.go
+++ b/pkg/discover/local.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/ellistarn/wt/pkg/worktree"
 )
@@ -21,38 +22,93 @@ func ListLocal() []worktree.Entry {
 
 	// Find .worktrees directories by walking with os.ReadDir, which uses
 	// the d_type field from readdir to check IsDir() without stat syscalls.
-	var all []worktree.Entry
+	// The callback is thread-safe because the walk parallelizes at depth 0.
+	var repos []string
 	seen := make(map[string]bool)
-	findWorktreeDirs(home, 0, 6, func(repo string) {
-		if seen[repo] {
-			return
+	var repoMu sync.Mutex
+	findWorktreeDirs(home, 0, 10, func(repo string) {
+		repoMu.Lock()
+		defer repoMu.Unlock()
+		if !seen[repo] {
+			seen[repo] = true
+			repos = append(repos, repo)
 		}
-		seen[repo] = true
-		all = append(all, listInRepo(repo)...)
 	})
+
+	// Query git in parallel across repos.
+	var mu sync.Mutex
+	var all []worktree.Entry
+	var wg sync.WaitGroup
+	for _, repo := range repos {
+		wg.Add(1)
+		go func(r string) {
+			defer wg.Done()
+			entries := listInRepo(r)
+			mu.Lock()
+			all = append(all, entries...)
+			mu.Unlock()
+		}(repo)
+	}
+	wg.Wait()
 	return all
 }
 
 // findWorktreeDirs walks directories looking for .worktrees entries.
-// Uses os.ReadDir which returns d_type from readdir (no stat per entry).
+// Uses three generic pruning strategies to stay fast on any filesystem:
+//  1. Hidden directories (starting with ".") are skipped.
+//  2. Git repo roots (.git detected) are leaf nodes — their children are
+//     source code, not nested repos. The walk root (depth 0) is exempt
+//     because $HOME is commonly a dotfiles repo containing real code repos.
+//  3. Directories with >100 children are skipped. Code-organizational
+//     directories (go/src/, github.com/org/) have low fan-out; only
+//     caches and artifact stores (Go module cache, node_modules) have
+//     hundreds of siblings.
 func findWorktreeDirs(dir string, depth, maxDepth int, fn func(repo string)) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}
+	hasGit := false
+	var children []string
 	for _, e := range entries {
+		name := e.Name()
+		if name == ".git" {
+			hasGit = true
+			continue
+		}
 		if !e.IsDir() {
 			continue
 		}
-		name := e.Name()
 		if name == ".worktrees" {
 			fn(dir)
 			continue
 		}
-		// Skip hidden directories and common heavy dirs
-		if strings.HasPrefix(name, ".") {
-			continue
+		if !strings.HasPrefix(name, ".") {
+			children = append(children, name)
 		}
+	}
+
+	if hasGit && depth > 0 {
+		return
+	}
+	if len(children) > 100 {
+		return
+	}
+	// Parallelize at the walk root — each top-level directory under $HOME
+	// gets its own goroutine so heavy subtrees don't block the rest.
+	if depth == 0 {
+		var wg sync.WaitGroup
+		for _, name := range children {
+			wg.Add(1)
+			go func(n string) {
+				defer wg.Done()
+				findWorktreeDirs(filepath.Join(dir, n), depth+1, maxDepth, fn)
+			}(name)
+		}
+		wg.Wait()
+		return
+	}
+	for _, name := range children {
 		if depth < maxDepth {
 			findWorktreeDirs(filepath.Join(dir, name), depth+1, maxDepth, fn)
 		}
@@ -78,10 +134,9 @@ func parseWorktreeList(porcelain, repo string) []worktree.Entry {
 			currentWT = strings.TrimPrefix(line, "worktree ")
 		}
 		if strings.HasPrefix(line, "branch ") && currentWT != "" {
-			branch := strings.TrimPrefix(line, "branch refs/heads/")
 			if strings.HasPrefix(currentWT, wtPrefix) {
 				e := worktree.Entry{
-					Name: branch,
+					Name: strings.TrimPrefix(currentWT, wtPrefix),
 					Dir:  currentWT,
 					Repo: repo,
 				}

--- a/pkg/discover/remote.go
+++ b/pkg/discover/remote.go
@@ -1,7 +1,7 @@
 package discover
 
 import (
-	"fmt"
+	"path"
 	"strconv"
 	"strings"
 
@@ -10,19 +10,26 @@ import (
 )
 
 // ListRemote finds all worktrees on the remote host.
+// Uses find to walk the home directory (no depth limit from hardcoded globs),
+// prunes hidden dirs for speed, and collects worktree metadata including
+// timestamps in a single SSH call.
 func ListRemote(host string) []worktree.Entry {
 	script := `
 set -eu
 home=$(readlink -f "$HOME")
-shopt -s nullglob
-for wt_dir in "$home"/.worktrees "$home"/*/.worktrees "$home"/*/*/.worktrees "$home"/*/*/*/.worktrees "$home"/*/*/*/*/.worktrees "$home"/*/*/*/*/*/.worktrees; do
+find "$home" -maxdepth 10 -type d \( -name .worktrees -print -prune -o -name '.*' -prune \) | while IFS= read -r wt_dir; do
     repo="${wt_dir%/.worktrees}"
     if [ -d "$repo/.git" ] || [ -f "$repo/.git" ]; then
         git -C "$repo" worktree list --porcelain 2>/dev/null | awk -v repo="$repo" '
             /^worktree / { wt=$2 }
             /^branch / {
                 br=$2; sub(/^refs\/heads\//, "", br)
-                if (wt ~ /\/.worktrees\//) print wt "\t" br "\t" repo
+                if (wt ~ /\/.worktrees\//) {
+                    cmd = "stat -c %Y \"" wt "/.git\" 2>/dev/null || echo 0"
+                    cmd | getline ts
+                    close(cmd)
+                    print wt "\t" br "\t" repo "\t" ts
+                }
             }
         '
     fi
@@ -33,43 +40,23 @@ done
 		return nil
 	}
 
-	// Collect worktree paths to batch-stat their .git files for creation time
-	var lines []string
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if line != "" {
-			lines = append(lines, line)
-		}
-	}
-	if len(lines) == 0 {
-		return nil
-	}
-
-	// Build a batch stat command for all .git files
-	var statPaths []string
-	for _, line := range lines {
-		parts := strings.SplitN(line, "\t", 3)
-		if len(parts) >= 1 {
-			statPaths = append(statPaths, fmt.Sprintf("'%s/.git'", parts[0]))
-		}
-	}
-	statScript := fmt.Sprintf("stat -c '%%Y' %s 2>/dev/null || true", strings.Join(statPaths, " "))
-	statOut, _ := ssh.Run(host, statScript)
-	statLines := strings.Split(strings.TrimSpace(statOut), "\n")
-
 	var entries []worktree.Entry
-	for i, line := range lines {
-		parts := strings.SplitN(line, "\t", 3)
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 4)
 		if len(parts) < 3 {
 			continue
 		}
 		e := worktree.Entry{
 			Dir:    parts[0],
-			Name:   parts[1],
+			Name:   path.Base(parts[0]),
 			Repo:   parts[2],
 			Remote: true,
 		}
-		if i < len(statLines) {
-			if ts, err := strconv.ParseInt(strings.TrimSpace(statLines[i]), 10, 64); err == nil {
+		if len(parts) >= 4 {
+			if ts, err := strconv.ParseInt(strings.TrimSpace(parts[3]), 10, 64); err == nil {
 				e.CreatedAt = worktree.TimeUnix(ts)
 			}
 		}

--- a/pkg/opencode/query.go
+++ b/pkg/opencode/query.go
@@ -85,7 +85,9 @@ func queryFromDB(host, dbFilePath string, dirs []string) []sessionRecord {
 		b, e := c.Output()
 		out, err = string(b), e
 	} else {
-		cmd := fmt.Sprintf("sqlite3 -separator '\t' \"%s\" \"%s\"", dbFilePath, query)
+		// Escape double quotes so the LIKE pattern survives shell double-quoting.
+		escaped := strings.ReplaceAll(query, `"`, `\"`)
+		cmd := fmt.Sprintf("sqlite3 -separator '\t' \"%s\" \"%s\"", dbFilePath, escaped)
 		out, err = ssh.Run(host, cmd)
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary

Three bugs fixed:
- Name derived from directory, not branch — worktrees stay findable after
  branch rename (e.g. `0423T2335-53114` was hidden behind its new branch name)
- Remote session status always showed idle — shell double-quoting stripped
  quotes from the SQL LIKE pattern
- Remote discovery used 6 hardcoded glob levels — replaced with `find`

Performance (`wt ls`):
- Prune walk at `.git` boundaries — repo source trees are leaf nodes
- Skip directories with >100 children — caches, not code
- Parallelize walk at `$HOME` level, git queries across repos, and
  enrichment with discovery
- **20s -> 3s** with zero hardcoded paths