### PR TITLE
Unified server model: always attach to persistent OpenCode server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build test vet presubmit
+
+presubmit: vet build test
+
+build:
+	go build ./...
+
+vet:
+	go vet ./...
+
+test:
+	go test -v ./...

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -8,9 +8,8 @@ gets an isolated working copy on its own branch, confined to its own directory.
 OpenCode enforces the boundary -- given a directory, it stays in it.
 
 Agents run for minutes or hours, and the laptop closes. Local processes die. Work
-must survive beyond the laptop. This requires a persistent remote environment: an
-OpenCode server on a dev desktop that runs continuously, with sessions that outlive
-any client connection.
+must survive beyond the laptop. This requires a persistent environment: OpenCode
+servers that run continuously, with sessions that outlive any client connection.
 
 The developer thinks in worktrees, not sessions, ports, or connection strings.
 "Show me everything in flight. Attach to that one." `wt` binds git worktrees to
@@ -32,28 +31,37 @@ managed from within OpenCode, not by this tool.
 A session is **working** when the agent is actively generating a response, and
 **idle** otherwise. A worktree with no session has no status.
 
-The **OpenCode server** is a persistent process on the dev desktop. One server
-hosts all worktrees across all repos. Every API endpoint accepts a `directory`
-parameter to scope requests to a specific worktree. TUI clients are stateless --
-they re-fetch everything on connect.
+An **OpenCode server** is a persistent process running `opencode serve`. One
+server hosts all worktrees across all repos. Every API endpoint accepts a
+`directory` parameter to scope requests to a specific worktree. TUI clients are
+stateless -- they re-fetch everything on connect.
+
+Multiple TUI clients can attach to the same server and session simultaneously.
+OpenCode synchronizes state across clients via server-sent events.
 
 ## Topology
 
+Local and remote worktrees use the same architecture: a persistent OpenCode
+server with TUI clients attached via `opencode attach`.
+
 ### Local
 
-OpenCode runs with its embedded server. The worktree and session live on the
-laptop. Sessions do not survive laptop close.
+The OpenCode server runs on the laptop as a daemon (e.g. launchd) at a known
+port (`localhost:9000`). Worktrees and sessions live on the laptop.
 
 ```
-wt
-└── opencode              # in <repo>/.worktrees/<name>
+laptop
+  opencode serve --port 9000         # daemon, always running
+       │
+  wt <name> ──> opencode attach http://localhost:9000
+                  --dir <repo>/.worktrees/<name>
+                  --session <id>
 ```
 
 ### Remote
 
-The worktree lives on the dev desktop, created over SSH. A persistent OpenCode
-server manages the session. The TUI runs locally, connecting to the remote server
-through an SSH tunnel.
+The OpenCode server runs on the dev desktop. TUI clients connect through an SSH
+tunnel.
 
 ```
 laptop                                  dev desktop
@@ -61,10 +69,11 @@ laptop                                  dev desktop
                                                 │
   opencode attach ────tunnel────────> opencode serve
     --dir <remote worktree path>
+    --session <id>
 ```
 
-Sessions survive laptop close. On reattach, the TUI reconnects and loads the full
-session state, including any work the agent completed while disconnected.
+Sessions survive laptop close. On reattach, the TUI reconnects and loads the
+full session state, including any work the agent completed while disconnected.
 
 ## CLI
 
@@ -74,8 +83,6 @@ Create or resume a worktree.
 
 - No args: create a new worktree in the current repo. Attach.
 - With `name`: resume `<repo>/.worktrees/<name>`. Attach.
-
-Attach: run `opencode` in the worktree directory.
 
 ### `wt -r <path> [name]`
 
@@ -87,9 +94,19 @@ Create or resume a remote worktree.
 - Without `name`: create a new worktree. Attach.
 - With `name`: resume existing worktree. Attach.
 
-Attach: query the OpenCode server for the most recent session in the worktree,
-then `opencode attach` to the remote server with the worktree directory and
-session ID.
+### Attach
+
+All attach operations follow the same steps:
+
+1. Resolve the server URL (local: `http://localhost:9000`, remote: tunnel URL).
+2. Health check: `GET /global/health`. Fail with a clear message if the server
+   is not running.
+3. Query `GET /session` filtered by the worktree directory. Select the most
+   recently updated session.
+4. Run `opencode attach <server> --dir <dir> --session <id>`.
+
+If no session exists for the worktree, `opencode attach` is run without
+`--session`. OpenCode creates a new session on first prompt.
 
 ### `wt ls`
 
@@ -97,11 +114,21 @@ List all worktrees and their session status. Local worktrees (all repos under
 `$HOME`) and remote worktrees (all repos on the dev desktop) are discovered
 concurrently and merged into a single table sorted by most recent activity.
 
+Session metadata is fetched from the OpenCode server API, not from the database
+directly. For each server (local and remote):
+
+1. `GET /session?directory=<dir>` — per worktree, returns sessions across
+   projects. The most recently updated session is selected.
+2. `GET /session/<id>/message` — per session, sums assistant message tokens
+   for session size and derives working/idle from whether the last assistant
+   message has completed.
+
 ```
-WORKTREE            STATUS    TITLE                           AGE     ACTIVITY    REPO
-0423T1430-12847     working   Fix auth handler validation     3h ago  just now    [remote] /home/user/.../acme/api
-0423T1600-4419      idle      Refactor config parser          1d ago  5m ago      /Users/user/.../acme/api
-0421T1100-5531      -         -                               2d ago  -           [remote] /home/user/.../acme/web
+WORKTREE            TITLE                           STATUS    ACTIVITY  TOKENS  REPO                              AGE
+0423T1430-12847     Fix auth handler validation      attached  now       150k    [remote] /home/user/.../acme/api   3h
+0423T1600-4419      Refactor config parser           idle      5m        42k     /Users/user/.../acme/api           1d
+0423T1700-8812      Migrate database schema          working   now       12k     [remote] /home/user/.../acme/api   2h
+0421T1100-5531      -                                -         -         -       [remote] /home/user/.../acme/web   2d
 ```
 
 Columns:
@@ -109,43 +136,45 @@ Columns:
 | Column | Value |
 |--------|-------|
 | WORKTREE | Worktree directory name (the stable identifier even if the branch is renamed). |
-| STATUS | `working` (agent generating), `idle` (session exists, agent not generating). |
 | TITLE | Session title, auto-generated from the first prompt. |
-| AGE | When the worktree was created. |
-| ACTIVITY | When the most recent session in this worktree was last active. |
+| STATUS | Highest-priority state: `attached` (TUI client connected), `working` (agent generating, no client), `idle` (session exists, no activity). Attachment is detected by scanning local `opencode attach` processes. No session shows `-`. |
+| ACTIVITY | How recently the session was active. `now` when the agent is streaming. When idle, shows when the last assistant message completed (e.g. `5m`, `3h`, `1d`). |
+| TOKENS | Total input + output tokens across all assistant messages in the most recent session. Formatted as `12k`, `150k`. |
 | REPO | Repo root, shortened to `<home>/.../parent/name`. `[remote]` prefix for remote worktrees. |
+| AGE | When the worktree was created. |
 
 `-` in any column means the value is unavailable. A worktree with no session
-shows `-` for UPDATED, STATUS, and TITLE. Attaching to such a worktree creates
-a session; subsequent listings show its status and title.
+shows `-` for STATUS, ACTIVITY, TOKENS, and TITLE. Attaching to such a worktree
+creates a session on first prompt; subsequent listings show its status and title.
 
 ## Reconnection
 
 1. Laptop opens. SSH tunnel restarts.
 2. `wt ls` shows everything in flight.
-3. `wt -r ~/src/acme/api 0423T1430-12847` resumes.
+3. `wt 0423T1430-12847` resumes (works for both local and remote worktrees).
 
 ## Assumptions
 
 - An SSH tunnel to the dev desktop is established and maintained externally.
-- The OpenCode server runs persistently on the dev desktop, managed externally.
+- The OpenCode server runs persistently on both the laptop (daemon) and the dev
+  desktop, managed externally.
 - Worktree cleanup is handled externally.
 
 ## Implementation
 
 Go binary. Shells out to `ssh` for remote git operations and to `opencode` for
-TUI attachment. Queries the OpenCode SQLite database for session metadata in
-listings. Queries the OpenCode HTTP API for session discovery when attaching
-remotely.
+TUI attachment. Queries the OpenCode HTTP API for session metadata in listings
+and for session discovery when attaching.
 
 ## Scoped Out
 
 - Worktree cleanup.
-- OpenCode server lifecycle.
+- OpenCode server lifecycle (daemon setup, launchd plist).
 - SSH tunnel management.
 - Auto-reattach on laptop wake.
 - Session lifecycle (new, fork). Managed from within OpenCode.
 - Multiple remote hosts.
+- Conflict detection when running bare `opencode` alongside the daemon.
 
 ## Rejected Alternatives
 
@@ -161,3 +190,11 @@ and reconnects cleanly.
 
 **Separate local/remote tools** — Same workflow, different transport. One tool with
 a `-r` flag.
+
+**Embedded server for local** — Running bare `opencode` starts a new server per
+invocation. Double-attaching creates a second server with an empty session instead
+of joining the existing one. A persistent server with `opencode attach` gives
+consistent multi-client behavior.
+
+**SQLite for session metadata** — Querying the OpenCode database directly is a
+layer violation. The HTTP API is the stable contract.

--- a/main.go
+++ b/main.go
@@ -50,6 +50,11 @@ func main() {
 
 // cmdLocal handles: wt [name]
 func cmdLocal(args []string) {
+	serverURL := opencode.LocalServerURL()
+	if err := opencode.CheckHealth(serverURL); err != nil {
+		die("%v", err)
+	}
+
 	if len(args) == 0 {
 		// Create new local worktree
 		repo, err := git.RepoRoot("")
@@ -63,7 +68,7 @@ func cmdLocal(args []string) {
 		}
 		fmt.Printf("Created worktree: %s\n", name)
 		fmt.Printf("wt %s\n", name)
-		if err := runOpencode(wtDir); err != nil {
+		if err := attach(serverURL, wtDir, ""); err != nil {
 			die("%v", err)
 		}
 		return
@@ -76,13 +81,14 @@ func cmdLocal(args []string) {
 		die("worktree %q not found", name)
 	}
 	if !entry.Remote {
-		if err := runOpencode(entry.Dir); err != nil {
+		sessionID := opencode.FindLatestSession(serverURL, entry.Dir)
+		if err := attach(serverURL, entry.Dir, sessionID); err != nil {
 			die("%v", err)
 		}
 	} else {
-		serverURL := opencode.ServerURL()
-		sessionID := opencode.FindLatestSession(serverURL, entry.Dir)
-		if err := runOpencodeAttach(serverURL, entry.Dir, sessionID); err != nil {
+		remoteURL := opencode.RemoteServerURL()
+		sessionID := opencode.FindLatestSession(remoteURL, entry.Dir)
+		if err := attach(remoteURL, entry.Dir, sessionID); err != nil {
 			die("%v", err)
 		}
 	}
@@ -130,9 +136,9 @@ func cmdRemote(args []string) {
 		}
 	}
 
-	serverURL := opencode.ServerURL()
+	serverURL := opencode.RemoteServerURL()
 	sessionID := opencode.FindLatestSession(serverURL, wtDir)
-	if err := runOpencodeAttach(serverURL, wtDir, sessionID); err != nil {
+	if err := attach(serverURL, wtDir, sessionID); err != nil {
 		die("%v", err)
 	}
 }
@@ -192,7 +198,7 @@ func cmdLs(remoteOnly bool) {
 	go func() {
 		defer wg.Done()
 		local = <-localCh
-		opencode.EnrichLocal(local)
+		opencode.Enrich(opencode.LocalServerURL(), local)
 	}()
 
 	wg.Add(1)
@@ -200,7 +206,7 @@ func cmdLs(remoteOnly bool) {
 		defer wg.Done()
 		remote = <-remoteCh
 		if host != "" {
-			opencode.EnrichRemote(host, remote)
+			opencode.Enrich(opencode.RemoteServerURL(), remote)
 		}
 	}()
 
@@ -240,22 +246,8 @@ func die(format string, args ...any) {
 	os.Exit(1)
 }
 
-// runOpencode runs opencode as a subprocess in the given directory, clearing the
-// terminal on exit to remove opencode's startup banner from scrollback.
-func runOpencode(dir string) error {
-	binary, err := exec.LookPath("opencode")
-	if err != nil {
-		return fmt.Errorf("opencode not found in PATH")
-	}
-	if err := os.Chdir(dir); err != nil {
-		return fmt.Errorf("cannot cd to %s: %w", dir, err)
-	}
-	return runTUI(exec.Command(binary))
-}
-
-// runOpencodeAttach runs opencode attach as a subprocess, clearing the terminal
-// on exit to remove opencode's startup banner from scrollback.
-func runOpencodeAttach(serverURL, dir, sessionID string) error {
+// attach runs opencode attach as a subprocess, connecting to the given server.
+func attach(serverURL, dir, sessionID string) error {
 	binary, err := exec.LookPath("opencode")
 	if err != nil {
 		return fmt.Errorf("opencode not found in PATH")

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -14,25 +14,83 @@ import (
 func PrintTable(entries []worktree.Entry) {
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 
-	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tAGE\tACTIVITY\tREPO\n")
+	fmt.Fprintf(w, "WORKTREE\tTITLE\tSTATUS\tACTIVITY\tTOKENS\tREPO\tAGE\n")
 
 	now := time.Now()
 	for _, e := range entries {
-		status := e.Status
-		if status == "" {
-			status = "-"
-		}
+		status := formatStatus(e.Status, e.Attached)
+		activity := formatActivity(e.UpdatedAt, now)
+		tokens := formatTokens(e.Tokens)
 		title := e.Title
 		if title == "" {
 			title = "-"
 		}
-		age := formatAge(e.CreatedAt, now)
-		activity := formatAge(e.UpdatedAt, now)
 		repo := formatRepo(e.Repo, e.Remote)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, age, activity, repo)
+		age := formatDuration(e.CreatedAt, now)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, title, status, activity, tokens, repo, age)
 	}
 
 	w.Flush()
+}
+
+// formatStatus returns the highest-priority state: attached > working > idle > -.
+func formatStatus(status string, attached bool) string {
+	if status == "" {
+		return "-"
+	}
+	if attached {
+		return "attached"
+	}
+	return status
+}
+
+// formatActivity returns how long ago the session was active, or "now" if streaming.
+func formatActivity(updatedAt time.Time, now time.Time) string {
+	if updatedAt.IsZero() {
+		return "-"
+	}
+	return formatDuration(updatedAt, now)
+}
+
+// formatDuration returns a compact relative time string.
+func formatDuration(t time.Time, now time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return "now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// formatTokens formats a token count as a compact string (e.g. "12k", "1.5M").
+func formatTokens(tokens int) string {
+	if tokens == 0 {
+		return "-"
+	}
+	switch {
+	case tokens < 1000:
+		return fmt.Sprintf("%d", tokens)
+	case tokens < 1_000_000:
+		k := float64(tokens) / 1000
+		if k < 10 {
+			return fmt.Sprintf("%.1fk", k)
+		}
+		return fmt.Sprintf("%dk", int(k))
+	default:
+		m := float64(tokens) / 1_000_000
+		if m < 10 {
+			return fmt.Sprintf("%.1fM", m)
+		}
+		return fmt.Sprintf("%dM", int(m))
+	}
 }
 
 // formatRepo shortens the repo path to <home>/.../last/two and tags remote entries.
@@ -51,23 +109,4 @@ func formatRepo(repo string, remote bool) string {
 	return repo
 }
 
-func formatAge(t time.Time, now time.Time) string {
-	if t.IsZero() {
-		return "-"
-	}
-	d := now.Sub(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		return fmt.Sprintf("%dm ago", int(d.Minutes()))
-	case d < 24*time.Hour:
-		return fmt.Sprintf("%dh ago", int(d.Hours()))
-	default:
-		days := int(d.Hours() / 24)
-		if days == 1 {
-			return "1d ago"
-		}
-		return fmt.Sprintf("%dd ago", days)
-	}
-}
+

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -1,0 +1,170 @@
+package display
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellistarn/wt/pkg/worktree"
+)
+
+func TestFormatStatus(t *testing.T) {
+	tests := []struct {
+		status   string
+		attached bool
+		want     string
+	}{
+		{"", false, "-"},
+		{"idle", false, "idle"},
+		{"working", false, "working"},
+		{"idle", true, "attached"},
+		{"working", true, "attached"},
+	}
+	for _, tt := range tests {
+		got := formatStatus(tt.status, tt.attached)
+		if got != tt.want {
+			t.Errorf("formatStatus(%q, %v) = %q, want %q", tt.status, tt.attached, got, tt.want)
+		}
+	}
+}
+
+func TestFormatTokens(t *testing.T) {
+	tests := []struct {
+		tokens int
+		want   string
+	}{
+		{0, "-"},
+		{500, "500"},
+		{999, "999"},
+		{1000, "1.0k"},
+		{1500, "1.5k"},
+		{9999, "10.0k"},
+		{10000, "10k"},
+		{42000, "42k"},
+		{150000, "150k"},
+		{999999, "999k"},
+		{1000000, "1.0M"},
+		{1500000, "1.5M"},
+		{10000000, "10M"},
+		{25000000, "25M"},
+	}
+	for _, tt := range tests {
+		got := formatTokens(tt.tokens)
+		if got != tt.want {
+			t.Errorf("formatTokens(%d) = %q, want %q", tt.tokens, got, tt.want)
+		}
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		t    time.Time
+		want string
+	}{
+		{time.Time{}, "-"},
+		{now.Add(-30 * time.Second), "now"},
+		{now.Add(-5 * time.Minute), "5m"},
+		{now.Add(-3 * time.Hour), "3h"},
+		{now.Add(-24 * time.Hour), "1d"},
+		{now.Add(-72 * time.Hour), "3d"},
+	}
+	for _, tt := range tests {
+		got := formatDuration(tt.t, now)
+		if got != tt.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tt.t, got, tt.want)
+		}
+	}
+}
+
+func TestFormatRepo(t *testing.T) {
+	tests := []struct {
+		repo   string
+		remote bool
+		want   string
+	}{
+		{"/Users/etarn/go/src/github.com/ellistarn/wt", false, "/Users/etarn/.../ellistarn/wt"},
+		{"/Users/etarn/go/src/github.com/ellistarn/wt", true, "[remote] /Users/etarn/.../ellistarn/wt"},
+		{"/short/path", false, "/short/path"},
+		{"/short/path", true, "[remote] /short/path"},
+	}
+	for _, tt := range tests {
+		got := formatRepo(tt.repo, tt.remote)
+		if got != tt.want {
+			t.Errorf("formatRepo(%q, %v) = %q, want %q", tt.repo, tt.remote, got, tt.want)
+		}
+	}
+}
+
+func TestPrintTable(t *testing.T) {
+	now := time.Now()
+	entries := []worktree.Entry{
+		{
+			Name:      "0424T0907-93511",
+			Dir:       "/Users/etarn/go/src/github.com/ellistarn/wt/.worktrees/0424T0907-93511",
+			Repo:      "/Users/etarn/go/src/github.com/ellistarn/wt",
+			Status:    "idle",
+			Title:     "Fix auth handler",
+			Tokens:    42000,
+			CreatedAt: now.Add(-3 * time.Hour),
+			UpdatedAt: now.Add(-5 * time.Minute),
+		},
+		{
+			Name:      "0424T1035-627",
+			Dir:       "/Users/etarn/go/src/github.com/ellistarn/wt/.worktrees/0424T1035-627",
+			Repo:      "/Users/etarn/go/src/github.com/ellistarn/wt",
+			CreatedAt: now.Add(-1 * time.Hour),
+		},
+	}
+
+	// Capture stdout by swapping os.Stdout with a pipe.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+
+	PrintTable(entries)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (header + 2 rows), got %d:\n%s", len(lines), output)
+	}
+
+	// Header should have the right columns.
+	header := lines[0]
+	for _, col := range []string{"WORKTREE", "TITLE", "STATUS", "ACTIVITY", "TOKENS", "REPO", "AGE"} {
+		if !strings.Contains(header, col) {
+			t.Errorf("header missing column %q: %s", col, header)
+		}
+	}
+
+	// First row: idle session with activity and tokens.
+	if !strings.Contains(lines[1], "idle") {
+		t.Errorf("expected 'idle' in row 1: %s", lines[1])
+	}
+	if !strings.Contains(lines[1], "5m") {
+		t.Errorf("expected '5m' activity in row 1: %s", lines[1])
+	}
+	if !strings.Contains(lines[1], "42k") {
+		t.Errorf("expected '42k' tokens in row 1: %s", lines[1])
+	}
+	if !strings.Contains(lines[1], "Fix auth handler") {
+		t.Errorf("expected title in row 1: %s", lines[1])
+	}
+
+	// Second row: no session, dashes everywhere.
+	if !strings.Contains(lines[2], "0424T1035-627") {
+		t.Errorf("expected worktree name in row 2: %s", lines[2])
+	}
+}

--- a/pkg/opencode/attach.go
+++ b/pkg/opencode/attach.go
@@ -1,0 +1,50 @@
+package opencode
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// AttachedDirs returns a map of worktree directories to the number of
+// opencode attach processes connected to them. Detection is based on
+// local process scanning (ps), so it only sees clients running on
+// this machine.
+func AttachedDirs() map[string]int {
+	out, err := exec.Command("ps", "-eo", "args").Output()
+	if err != nil {
+		return map[string]int{}
+	}
+
+	result := make(map[string]int)
+	for _, line := range strings.Split(string(out), "\n") {
+		dir := parseAttachDir(line)
+		if dir != "" {
+			result[dir]++
+		}
+	}
+
+	// Each attach shows up twice in ps (node wrapper + binary).
+	// Normalize to actual client count.
+	for dir := range result {
+		result[dir] = result[dir] / 2
+		if result[dir] == 0 {
+			result[dir] = 1
+		}
+	}
+	return result
+}
+
+// parseAttachDir extracts the --dir value from an "opencode attach" process
+// command line. Returns empty string if the line is not an attach process.
+func parseAttachDir(line string) string {
+	if !strings.Contains(line, "opencode") || !strings.Contains(line, "attach") {
+		return ""
+	}
+	fields := strings.Fields(line)
+	for i, f := range fields {
+		if f == "--dir" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
+}

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -1,0 +1,216 @@
+package opencode
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ellistarn/wt/pkg/worktree"
+)
+
+// skipIfNoServer skips the test if the local OpenCode server is not reachable.
+func skipIfNoServer(t *testing.T) string {
+	t.Helper()
+	serverURL := LocalServerURL()
+	if err := CheckHealth(serverURL); err != nil {
+		t.Skipf("local opencode server not running at %s", serverURL)
+	}
+	return serverURL
+}
+
+// findSessionDir returns a directory that has at least one session on the server.
+func findSessionDir(t *testing.T, serverURL string) string {
+	t.Helper()
+	sessions := fetchSessions(serverURL, "")
+	for _, s := range sessions {
+		if s.Directory != "" {
+			return s.Directory
+		}
+	}
+	t.Skip("no sessions with a directory on the server")
+	return ""
+}
+
+func TestHealthCheck(t *testing.T) {
+	serverURL := skipIfNoServer(t)
+	if err := CheckHealth(serverURL); err != nil {
+		t.Fatalf("expected healthy server at %s: %v", serverURL, err)
+	}
+}
+
+func TestHealthCheck_Unreachable(t *testing.T) {
+	if err := CheckHealth("http://localhost:1"); err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+}
+
+func TestFindLatestSession(t *testing.T) {
+	serverURL := skipIfNoServer(t)
+	dir := findSessionDir(t, serverURL)
+
+	sessionID := FindLatestSession(serverURL, dir)
+	if sessionID == "" {
+		t.Fatalf("no session found for %s", dir)
+	}
+	t.Logf("directory=%s session=%s", dir, sessionID)
+}
+
+func TestFindLatestSession_UnknownDir(t *testing.T) {
+	serverURL := skipIfNoServer(t)
+
+	sessionID := FindLatestSession(serverURL, "/nonexistent/path/xyz")
+	if sessionID != "" {
+		t.Fatalf("expected empty, got %s", sessionID)
+	}
+}
+
+func TestEnrich(t *testing.T) {
+	serverURL := skipIfNoServer(t)
+	dir := findSessionDir(t, serverURL)
+
+	entries := []worktree.Entry{
+		{
+			Name:      "known-worktree",
+			Dir:       dir,
+			Repo:      dir,
+			CreatedAt: time.Now().Add(-1 * time.Hour),
+		},
+		{
+			Name: "nonexistent-worktree",
+			Dir:  "/nonexistent/path/xyz",
+			Repo: "/nonexistent",
+		},
+	}
+
+	Enrich(serverURL, entries)
+
+	// First entry should be enriched.
+	e := entries[0]
+	if e.SessionID == "" {
+		t.Error("expected SessionID to be populated")
+	}
+	if e.Title == "" {
+		t.Error("expected Title to be populated")
+	}
+	if e.Status == "" {
+		t.Error("expected Status to be populated")
+	}
+	if e.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be populated")
+	}
+	if e.Tokens == 0 {
+		t.Error("expected Tokens > 0")
+	}
+	t.Logf("enriched: session=%s title=%q status=%s tokens=%d", e.SessionID, e.Title, e.Status, e.Tokens)
+
+	// Second entry should remain empty.
+	e2 := entries[1]
+	if e2.SessionID != "" {
+		t.Errorf("expected empty SessionID for unknown dir, got %s", e2.SessionID)
+	}
+	if e2.Tokens != 0 {
+		t.Errorf("expected zero tokens for unknown dir, got %d", e2.Tokens)
+	}
+}
+
+func TestEnrich_Empty(t *testing.T) {
+	serverURL := skipIfNoServer(t)
+	Enrich(serverURL, nil)
+	Enrich(serverURL, []worktree.Entry{})
+}
+
+// Bug 3: Enrich against an unreachable server should return quickly,
+// not hang for N * 5s (one timeout per entry).
+func TestEnrich_UnreachableServer(t *testing.T) {
+	entries := []worktree.Entry{
+		{Name: "a", Dir: "/fake/dir/a"},
+		{Name: "b", Dir: "/fake/dir/b"},
+		{Name: "c", Dir: "/fake/dir/c"},
+	}
+
+	// Use a non-routable IP to trigger actual TCP timeouts (not instant connection refused).
+	start := time.Now()
+	Enrich("http://192.0.2.1:9999", entries)
+	elapsed := time.Since(start)
+
+	if elapsed > 3*time.Second {
+		t.Errorf("Enrich against unreachable server took %v, expected < 3s", elapsed)
+	}
+
+	// Entries should remain untouched.
+	for _, e := range entries {
+		if e.SessionID != "" {
+			t.Errorf("expected empty SessionID, got %s", e.SessionID)
+		}
+	}
+}
+
+func TestTokenCounting(t *testing.T) {
+	serverURL := skipIfNoServer(t)
+
+	sessions := fetchSessions(serverURL, "")
+	if len(sessions) == 0 {
+		t.Skip("no sessions on server")
+	}
+
+	// Find a session with tokens.
+	for _, s := range sessions {
+		m := fetchSessionMetrics(serverURL, s.ID)
+		if m.tokens > 0 {
+			t.Logf("session %s (%q): %d tokens, status=%s", s.ID, s.Title, m.tokens, m.status)
+			return
+		}
+	}
+	t.Fatal("no sessions with tokens found")
+}
+
+// Bug 7: Status must be derived from message data, not the project-scoped
+// /session/status endpoint. Verify that Enrich populates status for
+// cross-project sessions.
+func TestEnrich_CrossProjectStatus(t *testing.T) {
+	serverURL := skipIfNoServer(t)
+
+	// Use a worktree directory that's in a different project than the server's.
+	sessions := fetchSessions(serverURL, "")
+	var crossDir string
+	for _, s := range sessions {
+		if strings.Contains(s.Directory, ".worktrees") {
+			crossDir = s.Directory
+			break
+		}
+	}
+	if crossDir == "" {
+		t.Skip("no cross-project sessions found")
+	}
+
+	entries := []worktree.Entry{
+		{Name: "cross", Dir: crossDir, Repo: crossDir, CreatedAt: time.Now()},
+	}
+	Enrich(serverURL, entries)
+
+	if entries[0].Status == "" {
+		t.Error("expected Status to be populated for cross-project session")
+	}
+	t.Logf("cross-project status=%s tokens=%d", entries[0].Status, entries[0].Tokens)
+}
+
+func TestAttachedDirs(t *testing.T) {
+	dirs := AttachedDirs()
+	// We can't predict exact results, but the function should not panic
+	// and should return a non-nil map.
+	if dirs == nil {
+		t.Fatal("AttachedDirs returned nil")
+	}
+	t.Logf("attached dirs: %v", dirs)
+
+	// If there are any opencode attach processes running, verify they
+	// have real directory paths.
+	for dir, count := range dirs {
+		if dir == "" {
+			t.Error("empty directory in AttachedDirs result")
+		}
+		if count < 1 {
+			t.Errorf("expected count >= 1 for %s, got %d", dir, count)
+		}
+	}
+}

--- a/pkg/opencode/query.go
+++ b/pkg/opencode/query.go
@@ -1,158 +1,209 @@
 package opencode
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
+	"encoding/json"
+	"net/url"
+	"sync"
 	"time"
 
-	"github.com/ellistarn/wt/pkg/ssh"
 	"github.com/ellistarn/wt/pkg/worktree"
 )
 
-// sessionRecord holds the fields needed from the SQLite session + last message.
-type sessionRecord struct {
-	id             string
-	dir            string
-	title          string
-	updated        int64
-	lastMsgRole    string
-	lastMsgUpdated int64
+// sessionMetrics holds token count and derived status from message data.
+type sessionMetrics struct {
+	tokens       int
+	status       string    // "working" or "idle"
+	lastActivity time.Time // when the session was last active
 }
 
-// deriveStatus infers session status from the last message.
-// While the agent is generating, the assistant message's time_updated advances
-// as tokens stream in. Once complete, it stops updating.
-func deriveStatus(r sessionRecord) string {
-	if r.lastMsgRole == "assistant" && r.lastMsgUpdated > 0 {
-		age := time.Since(time.UnixMilli(r.lastMsgUpdated))
-		if age < 60*time.Second {
-			return "working"
-		}
-	}
-	return "idle"
+// messageResponse is the API response for GET /session/:id/message.
+type messageResponse struct {
+	Info struct {
+		Role   string `json:"role"`
+		Time   *struct {
+			Created   int64  `json:"created"`
+			Completed *int64 `json:"completed,omitempty"`
+		} `json:"time,omitempty"`
+		Tokens *struct {
+			Input  int `json:"input"`
+			Output int `json:"output"`
+		} `json:"tokens,omitempty"`
+	} `json:"info"`
 }
 
-func dbPath() string {
-	dataDir := os.Getenv("XDG_DATA_HOME")
-	if dataDir == "" {
-		home, _ := os.UserHomeDir()
-		dataDir = filepath.Join(home, ".local", "share")
-	}
-	return filepath.Join(dataDir, "opencode", "opencode.db")
-}
-
-const sessionQuery = `
-SELECT s.id, s.directory, s.title, s.time_updated,
-       CASE WHEN m.data LIKE '%%"role":"assistant"%%' THEN 'assistant' ELSE '' END,
-       COALESCE(m.time_updated, 0)
-FROM session s
-LEFT JOIN message m ON m.session_id = s.id
-  AND m.time_created = (SELECT MAX(time_created) FROM message WHERE session_id = s.id)
-WHERE s.directory IN (%s)
-ORDER BY s.time_updated DESC
-`
-
-func queryLocalSessions(dirs []string) []sessionRecord {
-	if len(dirs) == 0 {
-		return nil
-	}
-	return queryFromDB("", dbPath(), dirs)
-}
-
-func queryRemoteSessions(host string, dirs []string) []sessionRecord {
-	if len(dirs) == 0 {
-		return nil
-	}
-	return queryFromDB(host, "$HOME/.local/share/opencode/opencode.db", dirs)
-}
-
-func queryFromDB(host, dbFilePath string, dirs []string) []sessionRecord {
-	quoted := make([]string, len(dirs))
-	for i, d := range dirs {
-		quoted[i] = "'" + strings.ReplaceAll(d, "'", "''") + "'"
-	}
-	query := fmt.Sprintf(sessionQuery, strings.Join(quoted, ","))
-
-	var out string
-	var err error
-	if host == "" {
-		// Run sqlite3 locally, passing the query via stdin to avoid shell quoting issues.
-		c := exec.Command("sqlite3", "-separator", "\t", dbFilePath)
-		c.Stdin = strings.NewReader(query)
-		b, e := c.Output()
-		out, err = string(b), e
-	} else {
-		// Escape double quotes so the LIKE pattern survives shell double-quoting.
-		escaped := strings.ReplaceAll(query, `"`, `\"`)
-		cmd := fmt.Sprintf("sqlite3 -separator '\t' \"%s\" \"%s\"", dbFilePath, escaped)
-		out, err = ssh.Run(host, cmd)
-	}
-	if err != nil {
-		return nil
+// Enrich populates worktree entries with session data from an OpenCode server.
+func Enrich(serverURL string, entries []worktree.Entry) {
+	if len(entries) == 0 {
+		return
 	}
 
-	var records []sessionRecord
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, "\t", 6)
-		if len(parts) < 6 {
-			continue
-		}
-		var updated, lastMsgUpdated int64
-		fmt.Sscanf(parts[3], "%d", &updated)
-		fmt.Sscanf(parts[5], "%d", &lastMsgUpdated)
-		records = append(records, sessionRecord{
-			id:             parts[0],
-			dir:            parts[1],
-			title:          parts[2],
-			updated:        updated,
-			lastMsgRole:    parts[4],
-			lastMsgUpdated: lastMsgUpdated,
-		})
-	}
-	return records
-}
-
-// EnrichLocal enriches worktree entries with local OpenCode session data.
-func EnrichLocal(entries []worktree.Entry) {
-	dirs := make([]string, len(entries))
-	for i, e := range entries {
-		dirs[i] = e.Dir
-	}
-	enrich(entries, queryLocalSessions(dirs))
-}
-
-// EnrichRemote enriches worktree entries with remote OpenCode session data.
-func EnrichRemote(host string, entries []worktree.Entry) {
-	dirs := make([]string, len(entries))
-	for i, e := range entries {
-		dirs[i] = e.Dir
-	}
-	enrich(entries, queryRemoteSessions(host, dirs))
-}
-
-func enrich(entries []worktree.Entry, records []sessionRecord) {
-	byDir := make(map[string]sessionRecord)
-	for _, r := range records {
-		existing, ok := byDir[r.dir]
-		if !ok || r.updated > existing.updated {
-			byDir[r.dir] = r
-		}
+	// Quick health check — if the server is down, skip enrichment entirely
+	// rather than waiting for N individual HTTP timeouts.
+	if err := checkHealthFast(serverURL); err != nil {
+		return
 	}
 
+	// Fetch sessions per directory concurrently. The session API is
+	// project-scoped, so an unfiltered GET /session only returns sessions
+	// for the server's own project. The directory parameter crosses
+	// project boundaries.
+	byDir := fetchSessionsByDir(serverURL, entries)
+	if len(byDir) == 0 {
+		return
+	}
+
+	// Match sessions to entries and collect IDs for metric fetching.
+	var sessionIDs []string
+	entrySessionMap := make(map[int]string) // entry index -> session ID
 	for i := range entries {
-		r, ok := byDir[entries[i].Dir]
+		s, ok := byDir[entries[i].Dir]
 		if !ok {
 			continue
 		}
-		entries[i].SessionID = r.id
-		entries[i].Title = r.title
-		entries[i].UpdatedAt = time.UnixMilli(r.updated)
-		entries[i].Status = deriveStatus(r)
+		entries[i].SessionID = s.ID
+		entries[i].Title = s.Title
+		entries[i].UpdatedAt = time.UnixMilli(s.Time.Updated)
+		sessionIDs = append(sessionIDs, s.ID)
+		entrySessionMap[i] = s.ID
 	}
+
+	// Fetch tokens and derive status from message data concurrently.
+	// Status is derived from whether the last assistant message is still
+	// streaming (no completion time), avoiding the project-scoped
+	// /session/status endpoint.
+	metricsBySession := fetchMetricsConcurrently(serverURL, sessionIDs)
+	for i, sid := range entrySessionMap {
+		if m, ok := metricsBySession[sid]; ok {
+			entries[i].Tokens = m.tokens
+			entries[i].Status = m.status
+			if !m.lastActivity.IsZero() {
+				entries[i].UpdatedAt = m.lastActivity
+			}
+		} else {
+			entries[i].Status = "idle"
+		}
+	}
+
+	// Detect locally attached TUI clients.
+	attached := AttachedDirs()
+	for i := range entries {
+		if count, ok := attached[entries[i].Dir]; ok && count > 0 {
+			entries[i].Attached = true
+		}
+	}
+}
+
+// fetchSessionsByDir queries GET /session?directory=<dir> for each entry
+// concurrently and returns the most recent session per directory.
+func fetchSessionsByDir(serverURL string, entries []worktree.Entry) map[string]session {
+	result := make(map[string]session)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, e := range entries {
+		wg.Add(1)
+		go func(dir string) {
+			defer wg.Done()
+			sessions := fetchSessions(serverURL, dir)
+			if len(sessions) == 0 {
+				return
+			}
+			// Pick the most recently updated session for this directory.
+			best := sessions[0]
+			for _, s := range sessions[1:] {
+				if s.Time.Updated > best.Time.Updated {
+					best = s
+				}
+			}
+			mu.Lock()
+			result[dir] = best
+			mu.Unlock()
+		}(e.Dir)
+	}
+
+	wg.Wait()
+	return result
+}
+
+// fetchSessions calls GET /session?directory=<dir> and returns matching sessions.
+func fetchSessions(serverURL, directory string) []session {
+	u := serverURL + "/session"
+	if directory != "" {
+		u += "?directory=" + url.QueryEscape(directory)
+	}
+	resp, err := httpGet(u)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var sessions []session
+	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+		return nil
+	}
+	return sessions
+}
+
+// fetchMetricsConcurrently fetches message data for each session, sums tokens,
+// and derives working/idle status.
+func fetchMetricsConcurrently(serverURL string, sessionIDs []string) map[string]sessionMetrics {
+	result := make(map[string]sessionMetrics)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, sid := range sessionIDs {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			m := fetchSessionMetrics(serverURL, id)
+			mu.Lock()
+			result[id] = m
+			mu.Unlock()
+		}(sid)
+	}
+
+	wg.Wait()
+	return result
+}
+
+// fetchSessionMetrics calls GET /session/:id/message and computes tokens
+// and status. A session is "working" if the last assistant message has no
+// completion time (the agent is still streaming).
+func fetchSessionMetrics(serverURL, sessionID string) sessionMetrics {
+	resp, err := httpGet(serverURL + "/session/" + sessionID + "/message")
+	if err != nil {
+		return sessionMetrics{status: "idle"}
+	}
+	defer resp.Body.Close()
+
+	var messages []messageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
+		return sessionMetrics{status: "idle"}
+	}
+
+	tokens := 0
+	for _, m := range messages {
+		if m.Info.Role == "assistant" && m.Info.Tokens != nil {
+			tokens += m.Info.Tokens.Input + m.Info.Tokens.Output
+		}
+	}
+
+	// Derive status and last activity from the last assistant message.
+	// If the agent is streaming (no completion time), activity is now.
+	// If idle, activity is when the last message completed.
+	status := "idle"
+	var lastActivity time.Time
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Info.Role == "assistant" && messages[i].Info.Time != nil {
+			if messages[i].Info.Time.Completed == nil {
+				status = "working"
+				lastActivity = time.Now()
+			} else {
+				lastActivity = time.UnixMilli(*messages[i].Info.Time.Completed)
+			}
+			break
+		}
+	}
+
+	return sessionMetrics{tokens: tokens, status: status, lastActivity: lastActivity}
 }

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -21,9 +21,17 @@ type session struct {
 	} `json:"time"`
 }
 
-// ServerURL returns the OpenCode server URL from environment or default.
-func ServerURL() string {
-	if u := os.Getenv("WT_SERVER"); u != "" {
+// LocalServerURL returns the local OpenCode server URL.
+func LocalServerURL() string {
+	if u := os.Getenv("WT_LOCAL_SERVER"); u != "" {
+		return u
+	}
+	return "http://localhost:9000"
+}
+
+// RemoteServerURL returns the remote OpenCode server URL.
+func RemoteServerURL() string {
+	if u := os.Getenv("WT_REMOTE_SERVER"); u != "" {
 		return u
 	}
 	port := os.Getenv("DEV_DESKTOP_TUNNEL_PORT")
@@ -31,6 +39,26 @@ func ServerURL() string {
 		port = "9847"
 	}
 	return fmt.Sprintf("http://opencode.etarn:%s", port)
+}
+
+// CheckHealth verifies that the OpenCode server is reachable.
+func CheckHealth(serverURL string) error {
+	resp, err := httpGet(serverURL + "/global/health")
+	if err != nil {
+		return fmt.Errorf("opencode server not reachable at %s", serverURL)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// checkHealthFast is a quick probe for use before batch operations.
+func checkHealthFast(serverURL string) error {
+	resp, err := httpGetTimeout(serverURL+"/global/health", 1*time.Second)
+	if err != nil {
+		return fmt.Errorf("opencode server not reachable at %s", serverURL)
+	}
+	resp.Body.Close()
+	return nil
 }
 
 // FindLatestSession queries the OpenCode server for the most recent session
@@ -60,7 +88,11 @@ func FindLatestSession(serverURL, directory string) string {
 }
 
 func httpGet(u string) (*http.Response, error) {
-	client := &http.Client{Timeout: 5 * time.Second}
+	return httpGetTimeout(u, 5*time.Second)
+}
+
+func httpGetTimeout(u string, timeout time.Duration) (*http.Response, error) {
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Get(u)
 	if err != nil {
 		return nil, err

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -18,6 +18,8 @@ type Entry struct {
 	SessionID string    // most recent OpenCode session ID (empty if none)
 	Status    string    // working or idle; empty if no session
 	Title     string    // OpenCode session title
+	Tokens    int       // total input+output tokens in the most recent session
+	Attached  bool      // true if a TUI client is attached to this worktree
 }
 
 // GenerateName returns a timestamped random name for a new worktree.


### PR DESCRIPTION
## Summary

- Replace the dual topology (bare `opencode` locally, `opencode attach` remotely) with a single architecture where both local and remote worktrees attach to a persistent OpenCode server
- Replace direct SQLite session queries with OpenCode HTTP API calls (`GET /session?directory=<dir>`, `GET /session/:id/message`)
- Derive working/idle status from message completion time (not the project-scoped `/session/status` endpoint)
- Detect attached TUI clients via local process scanning (`ps`)
- Status priority: `attached` > `working` > `idle`, with token count appended: `attached (42k)`
- Fast health check (1s) before enrichment to avoid hanging when server is down
- Add Makefile with `make presubmit` (vet + build + test)
- Add e2e + display tests (16 tests total)

## Motivation

Running `wt <name>` twice for a local worktree started two independent OpenCode servers, with the second showing an empty session. The unified model ensures all clients attach to the same persistent server, getting shared state via SSE events.