### PR TITLE
Suppress git subprocess noise during worktree creation

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -41,9 +41,10 @@ func WorktreeAdd(host, repo, name string) error {
 	if host == "" {
 		cmd := exec.Command("git", "worktree", "add", ".worktrees/"+name, "-b", name)
 		cmd.Dir = repo
-		cmd.Stdout = os.Stderr
-		cmd.Stderr = os.Stderr
-		return cmd.Run()
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("%w: %s", err, out)
+		}
+		return nil
 	}
 	script := fmt.Sprintf("cd '%s' && git worktree add '.worktrees/%s' -b '%s'", repo, name, name)
 	_, err := ssh.Run(host, script)


### PR DESCRIPTION
## Summary
- `git worktree add` prints "HEAD is now at ..." to stderr during local worktree creation. This was piped directly to the user's terminal via `cmd.Stderr = os.Stderr`.
- Switch to `CombinedOutput()` to capture subprocess output. Discard on success, wrap into the returned error on failure.
- Aligns the local path with the SSH path, which already captured and discarded output.