### PR TITLE
Fix token counting in wt ls

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -119,9 +119,9 @@ directly. For each server (local and remote):
 
 1. `GET /session?directory=<dir>` — per worktree, returns sessions across
    projects. The most recently updated session is selected.
-2. `GET /session/<id>/message` — per session, sums assistant message tokens
-   for session size and derives working/idle from whether the last assistant
-   message has completed.
+2. `GET /session/<id>/message` — per session, reads the last assistant
+   message's total token count (context window size) and derives working/idle
+   from whether that message has completed.
 
 ```
 WORKTREE            TITLE                           STATUS    ACTIVITY  TOKENS  REPO                              AGE
@@ -139,7 +139,7 @@ Columns:
 | TITLE | Session title, auto-generated from the first prompt. |
 | STATUS | Highest-priority state: `attached` (TUI client connected), `working` (agent generating, no client), `idle` (session exists, no activity). Attachment is detected by scanning local `opencode attach` processes. No session shows `-`. |
 | ACTIVITY | How recently the session was active. `now` when the agent is streaming. When idle, shows when the last assistant message completed (e.g. `5m`, `3h`, `1d`). |
-| TOKENS | Total input + output tokens across all assistant messages in the most recent session. Formatted as `12k`, `150k`. |
+| TOKENS | Context window size from the last assistant message in the most recent session. Formatted as `12k`, `150k`. |
 | REPO | Repo root, shortened to `<home>/.../parent/name`. `[remote]` prefix for remote worktrees. |
 | AGE | When the worktree was created. |
 

--- a/pkg/opencode/attach.go
+++ b/pkg/opencode/attach.go
@@ -6,9 +6,8 @@ import (
 )
 
 // AttachedDirs returns a map of worktree directories to the number of
-// opencode attach processes connected to them. Detection is based on
-// local process scanning (ps), so it only sees clients running on
-// this machine.
+// opencode TUI clients connected to them. Detection is based on scanning
+// local "opencode attach --dir <path>" processes.
 func AttachedDirs() map[string]int {
 	out, err := exec.Command("ps", "-eo", "args").Output()
 	if err != nil {

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -18,10 +18,22 @@ func skipIfNoServer(t *testing.T) string {
 	return serverURL
 }
 
-// findSessionDir returns a directory that has at least one session on the server.
+// findSessionDir returns a directory that has at least one session with
+// assistant messages on the server. Prefers sessions with tokens so that
+// enrichment tests can assert non-zero values.
 func findSessionDir(t *testing.T, serverURL string) string {
 	t.Helper()
 	sessions := fetchSessions(serverURL, "")
+	// First pass: prefer sessions with tokens.
+	for _, s := range sessions {
+		if s.Directory != "" {
+			m := fetchSessionMetrics(serverURL, s.ID)
+			if m.tokens > 0 {
+				return s.Directory
+			}
+		}
+	}
+	// Fallback: any session with a directory.
 	for _, s := range sessions {
 		if s.Directory != "" {
 			return s.Directory
@@ -212,5 +224,187 @@ func TestAttachedDirs(t *testing.T) {
 		if count < 1 {
 			t.Errorf("expected count >= 1 for %s, got %d", dir, count)
 		}
+	}
+}
+
+func TestParseAttachDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		wantDir string
+	}{
+		{
+			name:    "node wrapper",
+			line:    "/opt/homebrew/opt/node/bin/node /opt/homebrew/bin/opencode attach http://localhost:9000 --dir /Users/me/.worktrees/fix-auth",
+			wantDir: "/Users/me/.worktrees/fix-auth",
+		},
+		{
+			name:    "native binary",
+			line:    "/opt/homebrew/Cellar/opencode/1.4.10/libexec/lib/node_modules/opencode-ai/node_modules/opencode-darwin-arm64/bin/opencode attach http://localhost:9000 --dir /Users/me/.worktrees/fix-auth",
+			wantDir: "/Users/me/.worktrees/fix-auth",
+		},
+		{
+			name: "bare opencode ignored",
+			line: "/opt/homebrew/bin/opencode",
+		},
+		{
+			name: "server process ignored",
+			line: "/opt/homebrew/bin/opencode serve --port 9000",
+		},
+		{
+			name: "unrelated process",
+			line: "/usr/bin/vim",
+		},
+		{
+			name: "empty line",
+			line: "",
+		},
+		{
+			name: "attach without --dir",
+			line: "/opt/homebrew/bin/opencode attach http://localhost:9000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAttachDir(tt.line)
+			if got != tt.wantDir {
+				t.Errorf("got %q, want %q", got, tt.wantDir)
+			}
+		})
+	}
+}
+
+// helpers to build messageResponse values for unit tests.
+func msg(role string, total int, completed *int64) messageResponse {
+	var m messageResponse
+	m.Info.Role = role
+	if total > 0 {
+		m.Info.Tokens = &struct {
+			Total int `json:"total"`
+		}{Total: total}
+	}
+	if completed != nil || role == "assistant" {
+		m.Info.Time = &struct {
+			Created   int64  `json:"created"`
+			Completed *int64 `json:"completed,omitempty"`
+		}{Created: 1000, Completed: completed}
+	}
+	return m
+}
+
+func ptr(v int64) *int64 { return &v }
+
+func TestComputeMetrics(t *testing.T) {
+	tests := []struct {
+		name       string
+		messages   []messageResponse
+		wantTokens int
+		wantStatus string
+	}{
+		{
+			name:       "empty messages",
+			messages:   nil,
+			wantTokens: 0,
+			wantStatus: "idle",
+		},
+		{
+			name: "single completed assistant message",
+			messages: []messageResponse{
+				msg("user", 0, nil),
+				msg("assistant", 30000, ptr(2000)),
+			},
+			wantTokens: 30000,
+			wantStatus: "idle",
+		},
+		{
+			name: "streaming: last message has total=0, fallback to previous",
+			messages: []messageResponse{
+				msg("user", 0, nil),
+				msg("assistant", 50000, ptr(1000)),
+				msg("user", 0, nil),
+				msg("assistant", 0, nil), // streaming, no tokens yet
+			},
+			wantTokens: 50000,
+			wantStatus: "working",
+		},
+		{
+			name: "multiple completed messages uses last",
+			messages: []messageResponse{
+				msg("assistant", 10000, ptr(1000)),
+				msg("user", 0, nil),
+				msg("assistant", 25000, ptr(2000)),
+			},
+			wantTokens: 25000,
+			wantStatus: "idle",
+		},
+		{
+			name: "only user messages",
+			messages: []messageResponse{
+				msg("user", 0, nil),
+				msg("user", 0, nil),
+			},
+			wantTokens: 0,
+			wantStatus: "idle",
+		},
+		{
+			name: "streaming with no prior completed messages",
+			messages: []messageResponse{
+				msg("user", 0, nil),
+				msg("assistant", 0, nil), // streaming, first message
+			},
+			wantTokens: 0,
+			wantStatus: "working",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := computeMetrics(tt.messages)
+			if m.tokens != tt.wantTokens {
+				t.Errorf("tokens: got %d, want %d", m.tokens, tt.wantTokens)
+			}
+			if m.status != tt.wantStatus {
+				t.Errorf("status: got %q, want %q", m.status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// Regression: idle sessions with a streaming last message must use the
+// last *completed* message's activity time, not overwrite it with an
+// older message while scanning backwards for tokens.
+func TestComputeMetrics_RegressionIdleActivity(t *testing.T) {
+	messages := []messageResponse{
+		msg("assistant", 10000, ptr(1000)), // old
+		msg("user", 0, nil),
+		msg("assistant", 50000, ptr(5000)), // most recent completed
+		msg("user", 0, nil),
+		msg("assistant", 0, nil), // streaming
+	}
+	m := computeMetrics(messages)
+	if m.status != "working" {
+		t.Fatalf("status: got %q, want %q", m.status, "working")
+	}
+	if m.tokens != 50000 {
+		t.Errorf("tokens: got %d, want 50000", m.tokens)
+	}
+}
+
+func TestComputeMetrics_RegressionIdleNoOverwrite(t *testing.T) {
+	messages := []messageResponse{
+		msg("assistant", 10000, ptr(1000)), // old, completed at t=1000
+		msg("user", 0, nil),
+		msg("assistant", 0, ptr(5000)), // recent, completed at t=5000, no tokens
+	}
+	m := computeMetrics(messages)
+	// lastActivity should be from the LAST assistant message (t=5000),
+	// not overwritten by the earlier one (t=1000) during token scanning.
+	want := time.UnixMilli(5000)
+	if !m.lastActivity.Equal(want) {
+		t.Errorf("lastActivity: got %v, want %v", m.lastActivity, want)
+	}
+	if m.tokens != 10000 {
+		t.Errorf("tokens: got %d, want 10000", m.tokens)
 	}
 }

--- a/pkg/opencode/query.go
+++ b/pkg/opencode/query.go
@@ -25,8 +25,7 @@ type messageResponse struct {
 			Completed *int64 `json:"completed,omitempty"`
 		} `json:"time,omitempty"`
 		Tokens *struct {
-			Input  int `json:"input"`
-			Output int `json:"output"`
+			Total int `json:"total"`
 		} `json:"tokens,omitempty"`
 	} `json:"info"`
 }
@@ -144,8 +143,8 @@ func fetchSessions(serverURL, directory string) []session {
 	return sessions
 }
 
-// fetchMetricsConcurrently fetches message data for each session, sums tokens,
-// and derives working/idle status.
+// fetchMetricsConcurrently fetches message data for each session concurrently,
+// deriving token counts and working/idle status.
 func fetchMetricsConcurrently(serverURL string, sessionIDs []string) map[string]sessionMetrics {
 	result := make(map[string]sessionMetrics)
 	var mu sync.Mutex
@@ -166,9 +165,10 @@ func fetchMetricsConcurrently(serverURL string, sessionIDs []string) map[string]
 	return result
 }
 
-// fetchSessionMetrics calls GET /session/:id/message and computes tokens
-// and status. A session is "working" if the last assistant message has no
-// completion time (the agent is still streaming).
+// fetchSessionMetrics calls GET /session/:id/message to get the context
+// window size (total tokens from the last assistant message) and status.
+// A session is "working" if the last assistant message has no completion
+// time (the agent is still streaming).
 func fetchSessionMetrics(serverURL, sessionID string) sessionMetrics {
 	resp, err := httpGet(serverURL + "/session/" + sessionID + "/message")
 	if err != nil {
@@ -181,26 +181,42 @@ func fetchSessionMetrics(serverURL, sessionID string) sessionMetrics {
 		return sessionMetrics{status: "idle"}
 	}
 
-	tokens := 0
-	for _, m := range messages {
-		if m.Info.Role == "assistant" && m.Info.Tokens != nil {
-			tokens += m.Info.Tokens.Input + m.Info.Tokens.Output
-		}
-	}
+	return computeMetrics(messages)
+}
 
-	// Derive status and last activity from the last assistant message.
-	// If the agent is streaming (no completion time), activity is now.
-	// If idle, activity is when the last message completed.
+// computeMetrics derives token count, status, and last activity from a list
+// of messages. Walks backwards through assistant messages:
+//   - Status comes from the last assistant message (streaming = working).
+//   - Tokens come from the last message with a non-zero total. A streaming
+//     message reports total=0 until completion, so we fall back to the
+//     previous completed message.
+func computeMetrics(messages []messageResponse) sessionMetrics {
+	tokens := 0
 	status := "idle"
+	statusSet := false
 	var lastActivity time.Time
 	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Info.Role == "assistant" && messages[i].Info.Time != nil {
-			if messages[i].Info.Time.Completed == nil {
-				status = "working"
-				lastActivity = time.Now()
-			} else {
-				lastActivity = time.UnixMilli(*messages[i].Info.Time.Completed)
+		if messages[i].Info.Role != "assistant" {
+			continue
+		}
+		// Status: only set once (from the very last assistant message).
+		if !statusSet {
+			statusSet = true
+			if messages[i].Info.Time != nil {
+				if messages[i].Info.Time.Completed == nil {
+					status = "working"
+					lastActivity = time.Now()
+				} else {
+					lastActivity = time.UnixMilli(*messages[i].Info.Time.Completed)
+				}
 			}
+		}
+		// Tokens: take the first non-zero total we find.
+		if tokens == 0 && messages[i].Info.Tokens != nil && messages[i].Info.Tokens.Total > 0 {
+			tokens = messages[i].Info.Tokens.Total
+		}
+		// Stop once we have both.
+		if tokens > 0 && statusSet {
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

Read the `total` field from the last completed assistant message instead of summing `input+output` across all messages. The `input` field is nearly always 1 (non-cached portion) while the real context window size is in `total` (input+output+cache). Streaming messages report total=0, so fall back to the previous completed message.

## Before/After

| Metric | Before | After |
|--------|--------|-------|
| TOKENS for 38k context session | ~5.6k | 38k |
| TOKENS during streaming | `-` (0) | previous completed message's total |

## Test coverage

- `TestComputeMetrics` — 6 table-driven cases + 2 regression tests for streaming fallback and lastActivity overwrite
- `TestParseAttachDir` — 7 cases covering node wrapper, native binary, bare, server, unrelated processes
- `TestComputeMetrics_RegressionIdleNoOverwrite` — guards against lastActivity being overwritten by older messages during backward scan