### PR TITLE
Add README, Apache 2.0 license, and simplify CLI surface

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Ellis Tarn
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# wt
+
+Worktree session manager for [OpenCode](https://opencode.ai).
+
+```
+$ wt ls
+WORKTREE            TITLE                              STATUS    ACTIVITY  TOKENS  REPO                                    AGE
+0424T0900-31337     Rewrite Linux scheduler in Rust     attached  now       380k    /home/torvalds/.../linux/kernel          3h
+0421T1030-00001     Implement quantum-safe cryptography working   now       240k    [remote] /home/satoshi/.../bitcoin/src   3d
+1213T0800-42069     Autonomous drone delivery           working   now       85k     /home/bezos/.../amazon/prime-air         12y
+0423T1600-12345     Add exceptions to Go                idle      6h        45k     /home/robpike/.../golang/go              1d
+1215T0900-80085     Actually open OpenAI                idle      10y       120k    /home/altman/.../openai/models           10y
+0423T0900-99999     -                                   -         -         -       /home/ellistarn/.../ellistarn/wt         1d
+```
+
+## Usage
+
+```
+wt                     # Create a new local worktree and attach
+wt <name>              # Attach to an existing worktree (local or remote)
+wt ls                  # List all worktrees
+wt -r <path>           # Create a new remote worktree and attach
+```

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -84,15 +84,14 @@ Create or resume a worktree.
 - No args: create a new worktree in the current repo. Attach.
 - With `name`: resume `<repo>/.worktrees/<name>`. Attach.
 
-### `wt -r <path> [name]`
+### `wt -r <path>`
 
-Create or resume a remote worktree.
+Create a new remote worktree.
 
 - `path` identifies the repo as a local-style path
   (e.g., `~/src/acme/api`), translated to the remote
   equivalent.
-- Without `name`: create a new worktree. Attach.
-- With `name`: resume existing worktree. Attach.
+- Creates a new worktree. Attach.
 
 ### Attach
 

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	// Dispatch
 	if len(remaining) > 0 && remaining[0] == "ls" {
-		cmdLs(remote)
+		cmdLs()
 		return
 	}
 
@@ -93,10 +93,10 @@ func cmdLocal(args []string) {
 	}
 }
 
-// cmdRemote handles: wt -r <path> [name]
+// cmdRemote handles: wt -r <path>
 func cmdRemote(args []string) {
 	if len(args) == 0 {
-		die("remote mode requires a repo path: wt -r <path> [name]")
+		die("remote mode requires a repo path: wt -r <path>")
 	}
 
 	host, err := ssh.Host()
@@ -117,22 +117,13 @@ func cmdRemote(args []string) {
 		die("not a git repo on remote: %s", remotePath)
 	}
 
-	var name, wtDir string
-	if len(args) < 2 {
-		// Create new worktree
-		name = worktree.GenerateName()
-		wtDir = repo + "/.worktrees/" + name
-		if err := git.WorktreeAdd(host, repo, name); err != nil {
-			die("failed to create remote worktree: %v", err)
-		}
-		fmt.Printf("wt %s\n", name)
-	} else {
-		name = args[1]
-		wtDir = repo + "/.worktrees/" + name
-		if !git.DirExists(host, wtDir) {
-			die("worktree not found on remote: %s", wtDir)
-		}
+	// Create new worktree
+	name := worktree.GenerateName()
+	wtDir := repo + "/.worktrees/" + name
+	if err := git.WorktreeAdd(host, repo, name); err != nil {
+		die("failed to create remote worktree: %v", err)
 	}
+	fmt.Printf("wt %s\n", name)
 
 	serverURL := opencode.RemoteServerURL()
 	sessionID := opencode.FindLatestSession(serverURL, wtDir)
@@ -165,25 +156,18 @@ func findWorktree(name string) (worktree.Entry, bool) {
 }
 
 // cmdLs handles: wt ls
-func cmdLs(remoteOnly bool) {
+func cmdLs() {
 	host := os.Getenv("DEV_DESKTOP_HOST")
 
 	// Run local and remote discovery concurrently
 	localCh := make(chan []worktree.Entry, 1)
 	remoteCh := make(chan []worktree.Entry, 1)
 
-	if !remoteOnly {
-		go func() { localCh <- discover.ListLocal() }()
-	} else {
-		localCh <- nil
-	}
+	go func() { localCh <- discover.ListLocal() }()
 
 	if host != "" {
 		go func() { remoteCh <- discover.ListRemote(host) }()
 	} else {
-		if remoteOnly {
-			die("DEV_DESKTOP_HOST is not set")
-		}
 		remoteCh <- nil
 	}
 
@@ -227,10 +211,8 @@ wt — worktree session manager
 Usage:
   wt                        Create a new local worktree and attach
   wt <name>                 Attach to an existing worktree (local or remote)
+  wt ls                     List all worktrees
   wt -r <path>              Create a new remote worktree and attach
-  wt -r <path> <name>       Attach to an existing remote worktree
-  wt ls                     List all worktrees (local and remote)
-  wt -r ls                  List remote worktrees only
 
 Flags:
   -r, --remote              Operate on the remote dev desktop

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -51,12 +50,3 @@ func WorktreeAdd(host, repo, name string) error {
 	return err
 }
 
-// DirExists checks whether a directory exists, locally or over SSH.
-func DirExists(host, path string) bool {
-	if host == "" {
-		info, err := os.Stat(path)
-		return err == nil && info.IsDir()
-	}
-	_, err := ssh.Run(host, fmt.Sprintf("test -d '%s'", path))
-	return err == nil
-}


### PR DESCRIPTION
## Summary
- Add lightweight README with one-liner description, `wt ls` example output, and usage reference
- Add Apache 2.0 license (sourced from GitHub API)
- Remove `wt -r <path> <name>` — `wt <name>` already handles remote attachment
- Remove `wt -r ls` — `wt ls` already shows everything
- Remove unused `git.DirExists`
- Update design doc to match simplified CLI