### PR TITLE
Pull latest before creating worktrees

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -81,8 +81,8 @@ full session state, including any work the agent completed while disconnected.
 
 Create or resume a worktree.
 
-- No args: pull the current branch from origin to ensure the worktree starts
-  from the latest remote state. Create a new worktree. Attach.
+- No args: pull the current branch to ensure the worktree starts from the
+  latest remote state. Create a new worktree. Attach.
 - With `name`: resume `<repo>/.worktrees/<name>`. Attach.
 
 ### `wt -r <path>`
@@ -92,7 +92,7 @@ Create a new remote worktree.
 - `path` identifies the repo as a local-style path
   (e.g., `~/src/acme/api`), translated to the remote
   equivalent.
-- Pulls the current branch from origin, then creates a new worktree. Attach.
+- Pulls the current branch, then creates a new worktree. Attach.
 
 ### Attach
 

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -81,7 +81,8 @@ full session state, including any work the agent completed while disconnected.
 
 Create or resume a worktree.
 
-- No args: create a new worktree in the current repo. Attach.
+- No args: pull the current branch from origin to ensure the worktree starts
+  from the latest remote state. Create a new worktree. Attach.
 - With `name`: resume `<repo>/.worktrees/<name>`. Attach.
 
 ### `wt -r <path>`
@@ -91,7 +92,7 @@ Create a new remote worktree.
 - `path` identifies the repo as a local-style path
   (e.g., `~/src/acme/api`), translated to the remote
   equivalent.
-- Creates a new worktree. Attach.
+- Pulls the current branch from origin, then creates a new worktree. Attach.
 
 ### Attach
 
@@ -180,6 +181,8 @@ creates a session on first prompt; subsequent listings show its status and title
 
 ## Assumptions
 
+- The repo root checkout is on the default branch and clean. Worktree creation
+  pulls this branch, so conflicts or uncommitted changes would cause a failure.
 - An SSH tunnel to the dev desktop is established and maintained externally.
 - The OpenCode server runs persistently on both the laptop (daemon) and the dev
   desktop, managed externally.

--- a/main.go
+++ b/main.go
@@ -68,6 +68,9 @@ func cmdLocal(args []string) {
 		}
 		name := worktree.GenerateName()
 		wtDir := repo + "/.worktrees/" + name
+		if err := git.Pull("", repo); err != nil {
+			die("failed to pull: %v", err)
+		}
 		if err := git.WorktreeAdd("", repo, name); err != nil {
 			die("failed to create worktree: %v", err)
 		}
@@ -125,6 +128,9 @@ func cmdRemote(args []string) {
 	// Create new worktree
 	name := worktree.GenerateName()
 	wtDir := repo + "/.worktrees/" + name
+	if err := git.Pull(host, repo); err != nil {
+		die("failed to pull: %v", err)
+	}
 	if err := git.WorktreeAdd(host, repo, name); err != nil {
 		die("failed to create remote worktree: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -27,13 +27,17 @@ func TestE2E_NoScreenClearOnExit(t *testing.T) {
 		t.Fatalf("build: %s\n%s", err, out)
 	}
 
-	// Create temp git repo with an initial commit
-	repo := t.TempDir()
+	// Create temp git repo with an origin remote and initial commit
+	tmp := t.TempDir()
+	bare := filepath.Join(tmp, "origin.git")
+	repo := filepath.Join(tmp, "repo")
 	for _, args := range [][]string{
-		{"git", "init", repo},
+		{"git", "init", "--bare", bare},
+		{"git", "clone", bare, repo},
 		{"git", "-C", repo, "config", "user.email", "test@test.com"},
 		{"git", "-C", repo, "config", "user.name", "Test"},
 		{"git", "-C", repo, "commit", "--allow-empty", "-m", "init"},
+		{"git", "-C", repo, "push", "origin", "main"},
 	} {
 		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
 			t.Fatalf("%v: %s\n%s", args, err, out)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -154,6 +154,21 @@ func Fetch(host, repo string) {
 	runGit(host, repo, "fetch", "origin")
 }
 
+// Pull fetches with prune and fast-forwards the current branch. Used before
+// creating worktrees so they branch from the latest remote state. Uses
+// --ff-only to fail explicitly if the local branch has diverged.
+func Pull(host, repo string) error {
+	if host == "" {
+		cmd := exec.Command("git", "-C", repo, "pull", "--ff-only", "--prune")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("%w: %s", err, out)
+		}
+		return nil
+	}
+	_, err := runGit(host, repo, "pull", "--ff-only", "--prune")
+	return err
+}
+
 // WorktreeRemove removes the worktree directory and deletes the branch.
 // git worktree remove deletes the directory; git branch -d deletes the branch
 // (only if merged, safe delete).


### PR DESCRIPTION
## Summary

- Worktrees now branch from the latest remote state. `wt` runs `git pull --ff-only --prune` before `git worktree add` in both local and remote creation paths.
- Uses `--ff-only` to fail explicitly if the local branch has diverged, preventing surprise merge commits on the default branch.
- Updates design to document the pull behavior and the assumption that the repo root is on the default branch and clean.
- Fixes PTY test to use a repo with an origin remote (required now that creation pulls).