### PR TITLE
Remove environment-specific defaults and improve error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ WORKTREE            TITLE                              STATUS    ACTIVITY  TOKEN
 1213T0800-42069     Autonomous drone delivery           working   now       85k     /home/bezos/.../amazon/prime-air         12y
 0423T1600-12345     Add exceptions to Go                idle      6h        45k     /home/robpike/.../golang/go              1d
 1215T0900-80085     Actually open OpenAI                idle      10y       120k    /home/altman/.../openai/models           10y
-0423T0900-99999     -                                   -         -         -       /home/ellistarn/.../ellistarn/wt         1d
+0423T0900-99999     -                                   -         -         -       /home/user/.../acme/toolkit             1d
 ```
 
 ## Usage
@@ -21,3 +21,13 @@ wt <name>              # Attach to an existing worktree (local or remote)
 wt ls                  # List all worktrees
 wt -r <path>           # Create a new remote worktree and attach
 ```
+
+## Configuration
+
+Environment variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `WT_REMOTE_HOST` | For `-r` operations | — | SSH hostname of the remote dev desktop |
+| `WT_LOCAL_SERVER` | No | `http://localhost:4100` | Local OpenCode server URL |
+| `WT_REMOTE_SERVER` | No | `http://localhost:4101` | Remote OpenCode server URL (via SSH tunnel) |

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -47,13 +47,13 @@ server with TUI clients attached via `opencode attach`.
 ### Local
 
 The OpenCode server runs on the laptop as a daemon (e.g. launchd) at a known
-port (`localhost:9000`). Worktrees and sessions live on the laptop.
+port (`localhost:4100`). Worktrees and sessions live on the laptop.
 
 ```
 laptop
-  opencode serve --port 9000         # daemon, always running
+  opencode serve --port 4100         # daemon, always running
        │
-  wt <name> ──> opencode attach http://localhost:9000
+  wt <name> ──> opencode attach http://localhost:4100
                   --dir <repo>/.worktrees/<name>
                   --session <id>
 ```
@@ -98,7 +98,7 @@ Create a new remote worktree.
 
 All attach operations follow the same steps:
 
-1. Resolve the server URL (local: `http://localhost:9000`, remote: tunnel URL).
+1. Resolve the server URL (local: `http://localhost:4100`, remote: `http://localhost:4101`).
 2. Health check: `GET /global/health`. Fail with a clear message if the server
    is not running.
 3. Query `GET /session` filtered by the worktree directory. Select the most

--- a/main.go
+++ b/main.go
@@ -159,21 +159,35 @@ func cmdRemote(args []string) {
 	})
 }
 
+type remoteResult struct {
+	entries []worktree.Entry
+	err     error
+}
+
 // findWorktree discovers all worktrees (local and remote) and returns the one matching name.
 func findWorktree(name string) (worktree.Entry, bool) {
-	host := os.Getenv("DEV_DESKTOP_HOST")
+	host := os.Getenv("WT_REMOTE_HOST")
 
 	localCh := make(chan []worktree.Entry, 1)
-	remoteCh := make(chan []worktree.Entry, 1)
+	remoteCh := make(chan remoteResult, 1)
 
 	go func() { localCh <- discover.ListLocal() }()
 	if host != "" {
-		go func() { remoteCh <- discover.ListRemote(host) }()
+		go func() {
+			entries, err := discover.ListRemote(host)
+			remoteCh <- remoteResult{entries, err}
+		}()
 	} else {
-		remoteCh <- nil
+		remoteCh <- remoteResult{}
 	}
 
-	all := append(<-localCh, <-remoteCh...)
+	local := <-localCh
+	rr := <-remoteCh
+	if rr.err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", rr.err)
+	}
+
+	all := append(local, rr.entries...)
 	for _, e := range all {
 		if e.Name == name {
 			return e, true
@@ -246,10 +260,10 @@ func cmdRm(args []string, remoteOnly bool) {
 // Returns any enrichment error — callers that make safety decisions must
 // check this; callers that only display can ignore it.
 func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
-	host := os.Getenv("DEV_DESKTOP_HOST")
+	host := os.Getenv("WT_REMOTE_HOST")
 
 	localCh := make(chan []worktree.Entry, 1)
-	remoteCh := make(chan []worktree.Entry, 1)
+	remoteCh := make(chan remoteResult, 1)
 
 	if !remoteOnly {
 		go func() { localCh <- discover.ListLocal() }()
@@ -258,37 +272,44 @@ func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
 	}
 
 	if host != "" {
-		go func() { remoteCh <- discover.ListRemote(host) }()
+		go func() {
+			entries, err := discover.ListRemote(host)
+			remoteCh <- remoteResult{entries, err}
+		}()
 	} else {
 		if remoteOnly {
-			die("DEV_DESKTOP_HOST is not set")
+			die("WT_REMOTE_HOST is not set\n\nRemote operations require an SSH host. Set the environment variable:\n\n  export WT_REMOTE_HOST=your-dev-desktop")
 		}
-		remoteCh <- nil
+		remoteCh <- remoteResult{}
 	}
 
 	// Discover in parallel, then enrich via server API.
-	var local, remote []worktree.Entry
-
-	local = <-localCh
-	remote = <-remoteCh
+	local := <-localCh
+	rr := <-remoteCh
+	if rr.err != nil {
+		if remoteOnly {
+			die("%v", rr.err)
+		}
+		fmt.Fprintf(os.Stderr, "warning: %v\n", rr.err)
+	}
 
 	var enrichErr error
 	if err := opencode.Enrich(opencode.LocalServerURL(), local); err != nil {
 		enrichErr = fmt.Errorf("local session query: %w", err)
 	}
-	if host != "" {
-		if err := opencode.Enrich(opencode.RemoteServerURL(), remote); err != nil {
+	if host != "" && rr.err == nil {
+		if err := opencode.Enrich(opencode.RemoteServerURL(), rr.entries); err != nil {
 			enrichErr = fmt.Errorf("remote session query: %w", err)
 		}
 	}
 
-	return append(local, remote...), enrichErr
+	return append(local, rr.entries...), enrichErr
 }
 
 // hostFor returns the SSH host for an entry, or "" for local entries.
 func hostFor(e worktree.Entry) string {
 	if e.Remote {
-		return os.Getenv("DEV_DESKTOP_HOST")
+		return os.Getenv("WT_REMOTE_HOST")
 	}
 	return ""
 }

--- a/pkg/discover/remote.go
+++ b/pkg/discover/remote.go
@@ -1,6 +1,7 @@
 package discover
 
 import (
+	"fmt"
 	"path"
 	"strconv"
 	"strings"
@@ -13,10 +14,10 @@ import (
 // Uses find to walk the home directory (no depth limit from hardcoded globs),
 // prunes hidden dirs for speed, and collects worktree metadata including
 // timestamps in a single SSH call.
-func ListRemote(host string) []worktree.Entry {
+func ListRemote(host string) ([]worktree.Entry, error) {
 	script := `
 set -eu
-home=$(readlink -f "$HOME")
+home=$(cd "$HOME" && pwd -P)
 find "$home" -maxdepth 10 -type d \( -name .worktrees -print -prune -o -name '.*' -prune \) | while IFS= read -r wt_dir; do
     repo="${wt_dir%/.worktrees}"
     if [ -d "$repo/.git" ] || [ -f "$repo/.git" ]; then
@@ -25,7 +26,7 @@ find "$home" -maxdepth 10 -type d \( -name .worktrees -print -prune -o -name '.*
             /^branch / {
                 br=$2; sub(/^refs\/heads\//, "", br)
                 if (wt ~ /\/.worktrees\//) {
-                    cmd = "stat -c %Y \"" wt "/.git\" 2>/dev/null || echo 0"
+				    cmd = "stat -c %Y \"" wt "/.git\" 2>/dev/null || stat -f %m \"" wt "/.git\" 2>/dev/null || echo 0"
                     cmd | getline ts
                     close(cmd)
                     print wt "\t" br "\t" repo "\t" ts
@@ -37,7 +38,7 @@ done
 `
 	out, err := ssh.Run(host, script)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("cannot connect to remote host %q: %w", host, err)
 	}
 
 	var entries []worktree.Entry
@@ -62,5 +63,5 @@ done
 		}
 		entries = append(entries, e)
 	}
-	return entries
+	return entries, nil
 }

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -105,10 +105,10 @@ func formatTokens(tokens int) string {
 // formatRepo shortens the repo path to <home>/.../last/two and tags remote entries.
 func formatRepo(repo string, remote bool) string {
 	parts := strings.Split(repo, "/")
-	// Shorten: keep first 3 segments (e.g., "", "Users", "etarn"), then .../, then last 2.
+	// Shorten: keep first 3 segments (e.g., "", "home", "user"), then .../, then last 2.
 	// Only shorten if there are more than 5 segments (home + at least 3 intermediate + 2 tail).
 	if len(parts) > 5 {
-		head := strings.Join(parts[:3], "/") // e.g., /Users/etarn
+		head := strings.Join(parts[:3], "/") // e.g., /home/user
 		tail := strings.Join(parts[len(parts)-2:], "/")
 		repo = head + "/.../" + tail
 	}

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -85,8 +85,8 @@ func TestFormatRepo(t *testing.T) {
 		remote bool
 		want   string
 	}{
-		{"/Users/etarn/go/src/github.com/ellistarn/wt", false, "/Users/etarn/.../ellistarn/wt"},
-		{"/Users/etarn/go/src/github.com/ellistarn/wt", true, "[remote] /Users/etarn/.../ellistarn/wt"},
+		{"/home/user/src/github.com/acme/project", false, "/home/user/.../acme/project"},
+		{"/home/user/src/github.com/acme/project", true, "[remote] /home/user/.../acme/project"},
 		{"/short/path", false, "/short/path"},
 		{"/short/path", true, "[remote] /short/path"},
 	}
@@ -104,8 +104,8 @@ func TestPrintTable(t *testing.T) {
 		{
 			Entry: worktree.Entry{
 				Name:      "0424T0907-93511",
-				Dir:       "/Users/etarn/go/src/github.com/ellistarn/wt/.worktrees/0424T0907-93511",
-				Repo:      "/Users/etarn/go/src/github.com/ellistarn/wt",
+				Dir:       "/home/user/src/github.com/acme/project/.worktrees/0424T0907-93511",
+				Repo:      "/home/user/src/github.com/acme/project",
 				Status:    "idle",
 				Title:     "Fix auth handler",
 				Tokens:    42000,
@@ -117,8 +117,8 @@ func TestPrintTable(t *testing.T) {
 		{
 			Entry: worktree.Entry{
 				Name:      "0424T1035-627",
-				Dir:       "/Users/etarn/go/src/github.com/ellistarn/wt/.worktrees/0424T1035-627",
-				Repo:      "/Users/etarn/go/src/github.com/ellistarn/wt",
+				Dir:       "/home/user/src/github.com/acme/project/.worktrees/0424T1035-627",
+				Repo:      "/home/user/src/github.com/acme/project",
 				CreatedAt: now.Add(-1 * time.Hour),
 			},
 			Status: "-",

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -46,21 +46,21 @@ func TestParseAttachDir(t *testing.T) {
 	}{
 		{
 			name:    "node wrapper",
-			line:    "/opt/homebrew/opt/node/bin/node /opt/homebrew/bin/opencode attach http://localhost:9000 --dir /Users/me/.worktrees/fix-auth",
-			wantDir: "/Users/me/.worktrees/fix-auth",
+			line:    "/usr/local/bin/node /usr/local/bin/opencode attach http://localhost:4100 --dir /home/me/.worktrees/fix-auth",
+			wantDir: "/home/me/.worktrees/fix-auth",
 		},
 		{
 			name:    "native binary",
-			line:    "/opt/homebrew/Cellar/opencode/1.4.10/libexec/lib/node_modules/opencode-ai/node_modules/opencode-darwin-arm64/bin/opencode attach http://localhost:9000 --dir /Users/me/.worktrees/fix-auth",
-			wantDir: "/Users/me/.worktrees/fix-auth",
+			line:    "/usr/lib/opencode/bin/opencode attach http://localhost:4100 --dir /home/me/.worktrees/fix-auth",
+			wantDir: "/home/me/.worktrees/fix-auth",
 		},
 		{
 			name: "bare opencode ignored",
-			line: "/opt/homebrew/bin/opencode",
+			line: "/usr/local/bin/opencode",
 		},
 		{
 			name: "server process ignored",
-			line: "/opt/homebrew/bin/opencode serve --port 9000",
+			line: "/usr/local/bin/opencode serve --port 4100",
 		},
 		{
 			name: "unrelated process",
@@ -72,7 +72,7 @@ func TestParseAttachDir(t *testing.T) {
 		},
 		{
 			name: "attach without --dir",
-			line: "/opt/homebrew/bin/opencode attach http://localhost:9000",
+			line: "/usr/local/bin/opencode attach http://localhost:4100",
 		},
 	}
 

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -41,7 +41,7 @@ func LocalServerURL() string {
 	if u := os.Getenv("WT_LOCAL_SERVER"); u != "" {
 		return u
 	}
-	return "http://localhost:9000"
+	return "http://localhost:4100"
 }
 
 // RemoteServerURL returns the remote OpenCode server URL.
@@ -49,11 +49,7 @@ func RemoteServerURL() string {
 	if u := os.Getenv("WT_REMOTE_SERVER"); u != "" {
 		return u
 	}
-	port := os.Getenv("DEV_DESKTOP_TUNNEL_PORT")
-	if port == "" {
-		port = "9847"
-	}
-	return fmt.Sprintf("http://opencode.etarn:%s", port)
+	return "http://localhost:4101"
 }
 
 // CheckHealth verifies that the OpenCode server is reachable.

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-// Host returns DEV_DESKTOP_HOST or an error if unset.
+// Host returns WT_REMOTE_HOST or an error if unset.
 func Host() (string, error) {
-	host := os.Getenv("DEV_DESKTOP_HOST")
+	host := os.Getenv("WT_REMOTE_HOST")
 	if host == "" {
-		return "", fmt.Errorf("DEV_DESKTOP_HOST is not set")
+		return "", fmt.Errorf("WT_REMOTE_HOST is not set\n\nRemote operations require an SSH host. Set the environment variable:\n\n  export WT_REMOTE_HOST=your-dev-desktop")
 	}
 	return host, nil
 }
@@ -31,13 +31,13 @@ func Run(host, cmd string) (string, error) {
 // ResolveRemoteHome resolves and caches the remote physical home directory.
 func ResolveRemoteHome(host string) (string, error) {
 	cacheDir, _ := os.UserCacheDir()
-	cachePath := filepath.Join(cacheDir, "wt-remote-home")
+	cachePath := filepath.Join(cacheDir, "wt-remote-home-"+host)
 
 	if data, err := os.ReadFile(cachePath); err == nil {
 		return strings.TrimSpace(string(data)), nil
 	}
 
-	out, err := Run(host, "readlink -f $HOME")
+	out, err := Run(host, `cd "$HOME" && pwd -P`)
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve remote HOME: %w", err)
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -189,7 +189,7 @@ func (e *testEnv) wt(args ...string) string {
 	cmd := exec.Command(wtBinary, args...)
 	cmd.Dir = e.repo
 	cmd.Env = append(os.Environ(),
-		"DEV_DESKTOP_HOST=",
+		"WT_REMOTE_HOST=",
 		"WT_LOCAL_SERVER="+e.mockURL,
 	)
 	out, err := cmd.CombinedOutput()
@@ -414,4 +414,65 @@ func TestBatchRm_SessionWorkingSkipped(t *testing.T) {
 	// Just-created session is "working" (< 60s) — data gate blocks
 	assertContains(t, out, "batch-working")
 	assertContains(t, out, "keep (working)")
+}
+
+// --- Remote host configuration tests ---
+
+// wtRaw runs the wt binary with explicit env overrides, returning combined output and exit code.
+func wtRaw(t *testing.T, env []string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(wtBinary, args...)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return string(out), exitErr.ExitCode()
+		}
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return string(out), 0
+}
+
+func TestRemote_HostNotSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+
+	base := []string{"WT_REMOTE_HOST=", "HOME=" + t.TempDir()}
+
+	out, code := wtRaw(t, base, "-r", "ls")
+	if code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	assertContains(t, out, "WT_REMOTE_HOST is not set")
+	assertContains(t, out, "export WT_REMOTE_HOST=")
+
+	out, code = wtRaw(t, base, "-r", "/tmp/fake")
+	if code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	assertContains(t, out, "WT_REMOTE_HOST is not set")
+	assertContains(t, out, "export WT_REMOTE_HOST=")
+}
+
+func TestRemote_HostUnreachable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+
+	base := []string{"WT_REMOTE_HOST=wt-nonexistent-host-test", "HOME=" + t.TempDir()}
+
+	out, code := wtRaw(t, base, "-r", "ls")
+	if code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	assertContains(t, out, "cannot connect to remote host")
+
+	out, code = wtRaw(t, base, "-r", "/tmp/fake")
+	if code == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	assertContains(t, out, "cannot resolve remote HOME")
 }

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -22,15 +22,15 @@ type sshTestEnv struct {
 
 func newSSHTestEnv(t *testing.T) *sshTestEnv {
 	t.Helper()
-	host := os.Getenv("DEV_DESKTOP_HOST")
+	host := os.Getenv("WT_REMOTE_HOST")
 	if host == "" {
-		t.Skip("DEV_DESKTOP_HOST not set, skipping SSH tests")
+		t.Skip("WT_REMOTE_HOST not set, skipping SSH tests")
 	}
 
 	name := fmt.Sprintf("wt-e2e-ssh-%d-%d", time.Now().UnixNano(), rand.Intn(100000))
 
 	// Resolve remote home (follow symlinks for path consistency)
-	remoteHome := strings.TrimSpace(sshRun(t, host, "readlink -f $HOME"))
+	remoteHome := strings.TrimSpace(sshRun(t, host, `cd "$HOME" && pwd -P`))
 	rootDir := remoteHome + "/" + name
 	repo := rootDir + "/repo"
 	dataDir := rootDir + "/data"
@@ -93,12 +93,12 @@ func (e *sshTestEnv) createSession(dir string) {
 		e.dataDir, dir))
 }
 
-// wt runs the local wt binary with DEV_DESKTOP_HOST set.
+// wt runs the local wt binary with WT_REMOTE_HOST set.
 func (e *sshTestEnv) wt(args ...string) string {
 	e.t.Helper()
 	cmd := exec.Command(wtBinary, args...)
 	cmd.Env = append(os.Environ(),
-		"DEV_DESKTOP_HOST="+e.host,
+		"WT_REMOTE_HOST="+e.host,
 		"XDG_DATA_HOME="+e.dataDir, // remote data dir — wt queries it over SSH
 	)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary
- Replace bespoke hostnames (`opencode.etarn`), ports (9000/9847), and env vars (`DEV_DESKTOP_HOST`, `DEV_DESKTOP_TUNNEL_PORT`) with generic `localhost:4100/4101` defaults and `WT_REMOTE_HOST`
- Surface SSH errors from `ListRemote` instead of returning silent nil — `wt -r ls` with an unreachable host now dies with a clear message instead of "No worktrees found"
- Replace GNU-only commands (`readlink -f`, `stat -c %Y`) with portable alternatives, namespace remote home cache by host
- Add e2e tests for host-not-set and host-unreachable error paths
- Add Configuration table to README documenting all env vars