### PR TITLE
Manage SSH tunnel lifecycle for remote operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,3 @@ Environment variables:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `WT_REMOTE_HOST` | For `-r` operations | — | SSH hostname of the remote dev desktop |
-| `WT_LOCAL_SERVER` | No | `http://localhost:4100` | Local OpenCode server URL |
-| `WT_REMOTE_SERVER` | No | `http://localhost:4101` | Remote OpenCode server URL (via SSH tunnel) |

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -46,34 +46,47 @@ server with TUI clients attached via `opencode attach`.
 
 ### Local
 
-The OpenCode server runs on the laptop as a daemon (e.g. launchd) at a known
-port (`localhost:4100`). Worktrees and sessions live on the laptop.
+The OpenCode server runs on the laptop as a daemon (e.g. launchd) on the
+default port (`localhost:4096`). Worktrees and sessions live on the laptop.
 
 ```
 laptop
-  opencode serve --port 4100         # daemon, always running
+  opencode serve                     # daemon, always running, port 4096
        │
-  wt <name> ──> opencode attach http://localhost:4100
+  wt <name> ──> opencode attach http://localhost:4096
                   --dir <repo>/.worktrees/<name>
                   --session <id>
 ```
 
 ### Remote
 
-The OpenCode server runs on the dev desktop. TUI clients connect through an SSH
-tunnel.
+Both machines run an OpenCode server on the default port (4096). `wt` maintains
+an SSH tunnel on port 4097 forwarding to the remote's 4096. TUI clients run
+locally, attaching through the tunnel.
 
 ```
-laptop                                  dev desktop
-  wt -r ~/src/acme/api ──SSH──>            git worktree add ...
-                                                │
-  opencode attach ────tunnel────────> opencode serve
-    --dir <remote worktree path>
-    --session <id>
+laptop                                       dev desktop
+  opencode serve                               opencode serve
+  (port 4096)                                  (port 4096)
+                                                        ▲
+  ssh -fNL 4097:localhost:4096 ─────────────────────────┘
+       (tunnel, long-lived)
+
+  wt <name> ──> opencode attach http://localhost:4097
+                  --dir <remote worktree path>
+                  --session <id>
 ```
 
 Sessions survive laptop close. On reattach, the TUI reconnects and loads the
 full session state, including any work the agent completed while disconnected.
+
+### Tunnel
+
+`wt` ensures the SSH tunnel exists before any remote HTTP operation. Health
+check: TCP connect to `localhost:4097`. If down, start
+`ssh -fNL 4097:localhost:4096 <host>`. The tunnel is long-lived (`ssh -f`
+backgrounds the process), shared across `wt` invocations. If the tunnel dies,
+the next invocation restarts it.
 
 ## CLI
 
@@ -98,7 +111,8 @@ Create a new remote worktree.
 
 All attach operations follow the same steps:
 
-1. Resolve the server URL (local: `http://localhost:4100`, remote: `http://localhost:4101`).
+1. Resolve the server URL (local: `http://localhost:4096`, remote:
+   `http://localhost:4097` via the SSH tunnel).
 2. Health check: `GET /global/health`. Fail with a clear message if the server
    is not running.
 3. Query `GET /session` filtered by the worktree directory. Select the most
@@ -175,17 +189,23 @@ creates a session on first prompt; subsequent listings show its status and title
 
 ## Reconnection
 
-1. Laptop opens. SSH tunnel restarts.
-2. `wt ls` shows everything in flight.
+1. Laptop opens.
+2. `wt ls` shows everything in flight (ensures the tunnel if a remote host is configured).
 3. `wt 0423T1430-12847` resumes (works for both local and remote worktrees).
 
 ## Assumptions
 
 - The repo root checkout is on the default branch and clean. Worktree creation
   pulls this branch, so conflicts or uncommitted changes would cause a failure.
-- An SSH tunnel to the dev desktop is established and maintained externally.
+- The remote host is reachable via SSH.
 - The OpenCode server runs persistently on both the laptop (daemon) and the dev
   desktop, managed externally.
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `WT_REMOTE_HOST` | For remote operations | — | SSH hostname of the remote dev desktop |
 
 ## Implementation
 
@@ -196,7 +216,6 @@ and for session discovery when attaching.
 ## Scoped Out
 
 - OpenCode server lifecycle (daemon setup, launchd plist).
-- SSH tunnel management.
 - Auto-reattach on laptop wake.
 - Session lifecycle (new, fork). Managed from within OpenCode.
 - Multiple remote hosts.
@@ -224,3 +243,14 @@ consistent multi-client behavior.
 
 **SQLite for session metadata** — Querying the OpenCode database directly is a
 layer violation. The HTTP API is the stable contract.
+
+**External SSH tunnel** — Couples `wt` to external infrastructure (launchd plist,
+shell aliases). The tunnel is a prerequisite for every remote operation; managing
+it internally makes the tool self-contained.
+
+**Per-command SSH tunnel** — SSH handshake costs ~500ms per invocation. A
+long-lived tunnel amortizes the cost across all `wt` commands.
+
+**Remote TUI over SSH** — Running the TUI on the remote host and forwarding the
+terminal adds latency to every keystroke and breaks the local-client model where
+`opencode attach` runs on the laptop.

--- a/main.go
+++ b/main.go
@@ -101,7 +101,14 @@ func cmdLocal(args []string) {
 		}
 		printExitRow(serverURL, entry)
 	} else {
-		remoteURL := opencode.RemoteServerURL()
+		host, err := ssh.Host()
+		if err != nil {
+			die("%v", err)
+		}
+		if err := ssh.EnsureTunnel(host); err != nil {
+			die("%v", err)
+		}
+		remoteURL := opencode.RemoteServerURL
 		sessionID := opencode.FindLatestSession(remoteURL, entry.Dir)
 		if err := attach(remoteURL, entry.Dir, sessionID); err != nil {
 			die("%v", err)
@@ -145,7 +152,10 @@ func cmdRemote(args []string) {
 	}
 	fmt.Printf("wt %s\n", name)
 
-	serverURL := opencode.RemoteServerURL()
+	if err := ssh.EnsureTunnel(host); err != nil {
+		die("%v", err)
+	}
+	serverURL := opencode.RemoteServerURL
 	sessionID := opencode.FindLatestSession(serverURL, wtDir)
 	if err := attach(serverURL, wtDir, sessionID); err != nil {
 		die("%v", err)
@@ -298,7 +308,9 @@ func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
 		enrichErr = fmt.Errorf("local session query: %w", err)
 	}
 	if host != "" && rr.err == nil {
-		if err := opencode.Enrich(opencode.RemoteServerURL(), rr.entries); err != nil {
+		if err := ssh.EnsureTunnel(host); err != nil {
+			enrichErr = fmt.Errorf("SSH tunnel: %w", err)
+		} else if err := opencode.Enrich(opencode.RemoteServerURL, rr.entries); err != nil {
 			enrichErr = fmt.Errorf("remote session query: %w", err)
 		}
 	}

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -46,12 +46,12 @@ func TestParseAttachDir(t *testing.T) {
 	}{
 		{
 			name:    "node wrapper",
-			line:    "/usr/local/bin/node /usr/local/bin/opencode attach http://localhost:4100 --dir /home/me/.worktrees/fix-auth",
+			line:    "/usr/local/bin/node /usr/local/bin/opencode attach http://localhost:4096 --dir /home/me/.worktrees/fix-auth",
 			wantDir: "/home/me/.worktrees/fix-auth",
 		},
 		{
 			name:    "native binary",
-			line:    "/usr/lib/opencode/bin/opencode attach http://localhost:4100 --dir /home/me/.worktrees/fix-auth",
+			line:    "/usr/lib/opencode/bin/opencode attach http://localhost:4096 --dir /home/me/.worktrees/fix-auth",
 			wantDir: "/home/me/.worktrees/fix-auth",
 		},
 		{
@@ -60,7 +60,7 @@ func TestParseAttachDir(t *testing.T) {
 		},
 		{
 			name: "server process ignored",
-			line: "/usr/local/bin/opencode serve --port 4100",
+			line: "/usr/local/bin/opencode serve --port 4096",
 		},
 		{
 			name: "unrelated process",
@@ -72,7 +72,7 @@ func TestParseAttachDir(t *testing.T) {
 		},
 		{
 			name: "attach without --dir",
-			line: "/usr/local/bin/opencode attach http://localhost:4100",
+			line: "/usr/local/bin/opencode attach http://localhost:4096",
 		},
 	}
 

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -41,16 +41,11 @@ func LocalServerURL() string {
 	if u := os.Getenv("WT_LOCAL_SERVER"); u != "" {
 		return u
 	}
-	return "http://localhost:4100"
+	return "http://localhost:4096"
 }
 
-// RemoteServerURL returns the remote OpenCode server URL.
-func RemoteServerURL() string {
-	if u := os.Getenv("WT_REMOTE_SERVER"); u != "" {
-		return u
-	}
-	return "http://localhost:4101"
-}
+// RemoteServerURL is the remote OpenCode server, always reached through the SSH tunnel.
+const RemoteServerURL = "http://localhost:4097"
 
 // CheckHealth verifies that the OpenCode server is reachable.
 func CheckHealth(serverURL string) error {

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -2,11 +2,16 @@ package ssh
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+// TunnelPort is the local port for the SSH tunnel to the remote OpenCode server.
+const TunnelPort = 4097
 
 // Host returns WT_REMOTE_HOST or an error if unset.
 func Host() (string, error) {
@@ -65,4 +70,41 @@ func ToRemotePath(localPath, remoteHome string) (string, error) {
 	}
 
 	return remoteHome + localPath[len(home):], nil
+}
+
+// EnsureTunnel ensures an SSH tunnel from localhost:4101 to the remote host's
+// port 4100 is running. If the tunnel is already up, this is a no-op. Otherwise,
+// starts ssh -fNL 4101:localhost:4100 <host> and waits for it to come up.
+// The tunnel is long-lived and shared across wt invocations.
+func EnsureTunnel(host string) error {
+	if tunnelHealthy() {
+		return nil
+	}
+	cmd := exec.Command("ssh", "-fNL", fmt.Sprintf("%d:localhost:4096", TunnelPort), host)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// Another process may have started the tunnel between our health
+		// check and this SSH invocation (race on "address already in use").
+		if tunnelHealthy() {
+			return nil
+		}
+		return fmt.Errorf("failed to start SSH tunnel to %s: %w: %s", host, err, strings.TrimSpace(string(out)))
+	}
+	// Wait for the tunnel to accept connections.
+	for i := 0; i < 20; i++ {
+		if tunnelHealthy() {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("SSH tunnel started but localhost:%d not reachable", TunnelPort)
+}
+
+// tunnelHealthy checks whether the tunnel port is accepting TCP connections.
+func tunnelHealthy() bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", TunnelPort), 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -73,8 +73,8 @@ func ToRemotePath(localPath, remoteHome string) (string, error) {
 }
 
 // EnsureTunnel ensures an SSH tunnel from localhost:4101 to the remote host's
-// port 4100 is running. If the tunnel is already up, this is a no-op. Otherwise,
-// starts ssh -fNL 4101:localhost:4100 <host> and waits for it to come up.
+// port 4096 is running. If the tunnel is already up, this is a no-op. Otherwise,
+// starts ssh -fNL 4101:localhost:4096 <host> and waits for it to come up.
 // The tunnel is long-lived and shared across wt invocations.
 func EnsureTunnel(host string) error {
 	if tunnelHealthy() {

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -1,0 +1,21 @@
+package ssh
+
+import "testing"
+
+func TestTunnelHealthy_NoListener(t *testing.T) {
+	// With nothing listening on the tunnel port, tunnelHealthy should return false.
+	// This validates the TCP probe without requiring an SSH host.
+	if tunnelHealthy() {
+		t.Skip("something is already listening on the tunnel port")
+	}
+}
+
+func TestEnsureTunnel_BadHost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	err := EnsureTunnel("wt-nonexistent-host-test")
+	if err == nil {
+		t.Fatal("expected error for unreachable host")
+	}
+}


### PR DESCRIPTION
## Summary

- Bring SSH tunnel management in-scope: `wt` ensures `ssh -fNL 4101:localhost:4100 <host>` is running before any remote HTTP operation (TCP health check, start if down, shared across invocations).
- Remove `WT_REMOTE_SERVER` env var — remote server URL is now the constant `http://localhost:4101`, always reached through the tunnel.
- Update design doc: new Topology/Remote diagram, Tunnel subsection, Configuration section, three rejected alternatives (external tunnel, per-command tunnel, remote TUI over SSH).