### PR TITLE
Fix stale port in EnsureTunnel comment (4101 -> 4097)

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -72,9 +72,9 @@ func ToRemotePath(localPath, remoteHome string) (string, error) {
 	return remoteHome + localPath[len(home):], nil
 }
 
-// EnsureTunnel ensures an SSH tunnel from localhost:4101 to the remote host's
+// EnsureTunnel ensures an SSH tunnel from localhost:4097 to the remote host's
 // port 4096 is running. If the tunnel is already up, this is a no-op. Otherwise,
-// starts ssh -fNL 4101:localhost:4096 <host> and waits for it to come up.
+// starts ssh -fNL 4097:localhost:4096 <host> and waits for it to come up.
 // The tunnel is long-lived and shared across wt invocations.
 func EnsureTunnel(host string) error {
 	if tunnelHealthy() {


### PR DESCRIPTION
## Summary
- Fix stale comment in `EnsureTunnel` that referenced port 4101 instead of 4097 (the actual `TunnelPort` constant)