### PR TITLE
Manage OpenCode server lifecycle on local and remote hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Environment variables:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `WT_REMOTE_HOST` | For `-r` operations | — | SSH hostname of the remote dev desktop |
+| `WT_OPENCODE_PORT` | No | `5096` | OpenCode server port (local and remote) |

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -46,33 +46,35 @@ server with TUI clients attached via `opencode attach`.
 
 ### Local
 
-The OpenCode server runs on the laptop as a daemon (e.g. launchd) on the
-default port (`localhost:4096`). Worktrees and sessions live on the laptop.
+The OpenCode server runs on the laptop on port 5096. `wt` ensures the server is
+running before any operation — if no server is healthy, `wt` starts
+`opencode serve --port 5096` as a detached process. The server outlives the `wt`
+invocation and is reused across commands.
 
 ```
 laptop
-  opencode serve                     # daemon, always running, port 4096
+  opencode serve                     # auto-started by wt, port 5096
        │
-  wt <name> ──> opencode attach http://localhost:4096
+  wt <name> ──> opencode attach http://localhost:5096
                   --dir <repo>/.worktrees/<name>
                   --session <id>
 ```
 
 ### Remote
 
-Both machines run an OpenCode server on the default port (4096). `wt` maintains
-an SSH tunnel on port 4097 forwarding to the remote's 4096. TUI clients run
-locally, attaching through the tunnel.
+Both machines run an OpenCode server on port 5096, each auto-started by `wt` on
+first use. `wt` maintains an SSH tunnel on port 5097 forwarding to the remote's
+5096. TUI clients run locally, attaching through the tunnel.
 
 ```
 laptop                                       dev desktop
   opencode serve                               opencode serve
-  (port 4096)                                  (port 4096)
+  (port 5096)                                  (port 5096)
                                                         ▲
-  ssh -fNL 4097:localhost:4096 ─────────────────────────┘
+  ssh -fNL 5097:localhost:5096 ─────────────────────────┘
        (tunnel, long-lived)
 
-  wt <name> ──> opencode attach http://localhost:4097
+  wt <name> ──> opencode attach http://localhost:5097
                   --dir <remote worktree path>
                   --session <id>
 ```
@@ -83,10 +85,34 @@ full session state, including any work the agent completed while disconnected.
 ### Tunnel
 
 `wt` ensures the SSH tunnel exists before any remote HTTP operation. Health
-check: TCP connect to `localhost:4097`. If down, start
-`ssh -fNL 4097:localhost:4096 <host>`. The tunnel is long-lived (`ssh -f`
+check: TCP connect to `localhost:5097`. If down, start
+`ssh -fNL 5097:localhost:5096 <host>`. The tunnel is long-lived (`ssh -f`
 backgrounds the process), shared across `wt` invocations. If the tunnel dies,
 the next invocation restarts it.
+
+### Server Lifecycle
+
+`wt` ensures an OpenCode server is running before any operation that needs one,
+using the same pattern as the tunnel: health check, start if not healthy, reuse
+across invocations.
+
+Locally, health check `GET /global/health` on `localhost:5096`. If down, start
+`opencode serve --port 5096` as a detached process. Remotely, the same health
+check goes through the tunnel (`localhost:5097`). If down, start the server via
+`ssh <host>`. Both cases poll until healthy or error.
+
+The server outlives the `wt` invocation. Multiple `wt` invocations reuse the
+same server without starting duplicates. If someone manually starts
+`opencode serve --port 5096`, `wt` reuses it. The server dies on reboot or
+crash; the next `wt` invocation restarts it.
+
+Both `wt`-managed and user-started servers share the same data directory
+(~/.opencode or configured). Sessions created on any port are visible to all
+servers — OpenCode servers are stateless API layers over SQLite.
+
+If the server dies mid-agent, the next `wt` command restarts it. OpenCode
+sessions are crash-tolerant — incomplete messages are treated as interrupted
+history, and reattaching resumes the session.
 
 ## CLI
 
@@ -111,10 +137,10 @@ Create a new remote worktree.
 
 All attach operations follow the same steps:
 
-1. Resolve the server URL (local: `http://localhost:4096`, remote:
-   `http://localhost:4097` via the SSH tunnel).
-2. Health check: `GET /global/health`. Fail with a clear message if the server
-   is not running.
+1. Resolve the server URL (local: `http://localhost:5096`, remote:
+   `http://localhost:5097` via the SSH tunnel).
+2. Ensure the server is running (local or tunnel + remote). Fail with a clear
+   message if the server cannot be started.
 3. Query `GET /session` filtered by the worktree directory. Select the most
    recently updated session.
 4. Run `opencode attach <server> --dir <dir> --session <id>`.
@@ -190,7 +216,7 @@ creates a session on first prompt; subsequent listings show its status and title
 ## Reconnection
 
 1. Laptop opens.
-2. `wt ls` shows everything in flight (ensures the tunnel if a remote host is configured).
+2. `wt ls` shows everything in flight (ensures the server and tunnel as needed).
 3. `wt 0423T1430-12847` resumes (works for both local and remote worktrees).
 
 ## Assumptions
@@ -198,14 +224,14 @@ creates a session on first prompt; subsequent listings show its status and title
 - The repo root checkout is on the default branch and clean. Worktree creation
   pulls this branch, so conflicts or uncommitted changes would cause a failure.
 - The remote host is reachable via SSH.
-- The OpenCode server runs persistently on both the laptop (daemon) and the dev
-  desktop, managed externally.
+- `opencode` is available on PATH (locally and on the remote host).
 
 ## Configuration
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `WT_REMOTE_HOST` | For remote operations | — | SSH hostname of the remote dev desktop |
+| `WT_OPENCODE_PORT` | No | `5096` | OpenCode server port (local and remote). Tunnel port is always server port + 1. |
 
 ## Implementation
 
@@ -215,11 +241,10 @@ and for session discovery when attaching.
 
 ## Scoped Out
 
-- OpenCode server lifecycle (daemon setup, launchd plist).
 - Auto-reattach on laptop wake.
 - Session lifecycle (new, fork). Managed from within OpenCode.
 - Multiple remote hosts.
-- Conflict detection when running bare `opencode` alongside the daemon.
+- Conflict detection when running bare `opencode` alongside the managed server.
 
 ## Rejected Alternatives
 
@@ -243,6 +268,12 @@ consistent multi-client behavior.
 
 **SQLite for session metadata** — Querying the OpenCode database directly is a
 layer violation. The HTTP API is the stable contract.
+
+**External server management** — Running `opencode serve` as a systemd unit or
+launchd plist requires manual setup on every machine and creates env-wiring
+problems (systemd does not inherit the user's shell environment — AWS
+credentials, PATH). `wt` starting the server as a detached child inherits the
+user's env and makes the tool self-contained.
 
 **External SSH tunnel** — Couples `wt` to external infrastructure (launchd plist,
 shell aliases). The tunnel is a prerequisite for every remote operation; managing

--- a/main.go
+++ b/main.go
@@ -56,10 +56,10 @@ func main() {
 
 // cmdLocal handles: wt [name]
 func cmdLocal(args []string) {
-	serverURL := opencode.LocalServerURL()
-	if err := opencode.CheckHealth(serverURL); err != nil {
+	if err := opencode.EnsureLocalServer(); err != nil {
 		die("%v", err)
 	}
+	serverURL := opencode.LocalServerURL()
 
 	if len(args) == 0 {
 		// Create new local worktree
@@ -105,10 +105,13 @@ func cmdLocal(args []string) {
 		if err != nil {
 			die("%v", err)
 		}
-		if err := ssh.EnsureTunnel(host); err != nil {
+		if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
 			die("%v", err)
 		}
-		remoteURL := opencode.RemoteServerURL
+		if err := opencode.EnsureRemoteServer(host); err != nil {
+			die("%v", err)
+		}
+		remoteURL := opencode.RemoteServerURL()
 		sessionID := opencode.FindLatestSession(remoteURL, entry.Dir)
 		if err := attach(remoteURL, entry.Dir, sessionID); err != nil {
 			die("%v", err)
@@ -152,10 +155,13 @@ func cmdRemote(args []string) {
 	}
 	fmt.Printf("wt %s\n", name)
 
-	if err := ssh.EnsureTunnel(host); err != nil {
+	if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
 		die("%v", err)
 	}
-	serverURL := opencode.RemoteServerURL
+	if err := opencode.EnsureRemoteServer(host); err != nil {
+		die("%v", err)
+	}
+	serverURL := opencode.RemoteServerURL()
 	sessionID := opencode.FindLatestSession(serverURL, wtDir)
 	if err := attach(serverURL, wtDir, sessionID); err != nil {
 		die("%v", err)
@@ -304,13 +310,19 @@ func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
 	}
 
 	var enrichErr error
-	if err := opencode.Enrich(opencode.LocalServerURL(), local); err != nil {
-		enrichErr = fmt.Errorf("local session query: %w", err)
+	if !remoteOnly {
+		if err := opencode.EnsureLocalServer(); err != nil {
+			enrichErr = fmt.Errorf("local server: %w", err)
+		} else if err := opencode.Enrich(opencode.LocalServerURL(), local); err != nil {
+			enrichErr = fmt.Errorf("local session query: %w", err)
+		}
 	}
 	if host != "" && rr.err == nil {
-		if err := ssh.EnsureTunnel(host); err != nil {
+		if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
 			enrichErr = fmt.Errorf("SSH tunnel: %w", err)
-		} else if err := opencode.Enrich(opencode.RemoteServerURL, rr.entries); err != nil {
+		} else if err := opencode.EnsureRemoteServer(host); err != nil {
+			enrichErr = fmt.Errorf("remote server: %w", err)
+		} else if err := opencode.Enrich(opencode.RemoteServerURL(), rr.entries); err != nil {
 			enrichErr = fmt.Errorf("remote session query: %w", err)
 		}
 	}

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -46,12 +46,12 @@ func TestParseAttachDir(t *testing.T) {
 	}{
 		{
 			name:    "node wrapper",
-			line:    "/usr/local/bin/node /usr/local/bin/opencode attach http://localhost:4096 --dir /home/me/.worktrees/fix-auth",
+			line:    "/usr/local/bin/node /usr/local/bin/opencode attach http://localhost:5096 --dir /home/me/.worktrees/fix-auth",
 			wantDir: "/home/me/.worktrees/fix-auth",
 		},
 		{
 			name:    "native binary",
-			line:    "/usr/lib/opencode/bin/opencode attach http://localhost:4096 --dir /home/me/.worktrees/fix-auth",
+			line:    "/usr/lib/opencode/bin/opencode attach http://localhost:5096 --dir /home/me/.worktrees/fix-auth",
 			wantDir: "/home/me/.worktrees/fix-auth",
 		},
 		{
@@ -60,7 +60,7 @@ func TestParseAttachDir(t *testing.T) {
 		},
 		{
 			name: "server process ignored",
-			line: "/usr/local/bin/opencode serve --port 4096",
+			line: "/usr/local/bin/opencode serve --port 5096",
 		},
 		{
 			name: "unrelated process",
@@ -72,7 +72,7 @@ func TestParseAttachDir(t *testing.T) {
 		},
 		{
 			name: "attach without --dir",
-			line: "/usr/local/bin/opencode attach http://localhost:4096",
+			line: "/usr/local/bin/opencode attach http://localhost:5096",
 		},
 	}
 

--- a/pkg/opencode/server.go
+++ b/pkg/opencode/server.go
@@ -1,0 +1,110 @@
+package opencode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/ellistarn/wt/pkg/ssh"
+)
+
+// ServerPort returns the OpenCode server port (default 5096, overridden by WT_OPENCODE_PORT).
+func ServerPort() int {
+	if s := os.Getenv("WT_OPENCODE_PORT"); s != "" {
+		if p, err := strconv.Atoi(s); err == nil {
+			return p
+		}
+	}
+	return 5096
+}
+
+// TunnelPort returns the local tunnel endpoint port (ServerPort + 1).
+func TunnelPort() int {
+	return ServerPort() + 1
+}
+
+// EnsureLocalServer ensures an OpenCode server is running locally.
+// If healthy, this is a no-op. Otherwise, starts opencode serve detached
+// and polls until healthy.
+func EnsureLocalServer() error {
+	port := ServerPort()
+	url := fmt.Sprintf("http://localhost:%d", port)
+
+	if healthProbe(url) == nil {
+		return nil
+	}
+
+	binary, err := exec.LookPath("opencode")
+	if err != nil {
+		return fmt.Errorf("opencode not found in PATH")
+	}
+
+	cmd := exec.Command(binary, "serve", "--port", strconv.Itoa(port))
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err == nil {
+		cmd.Stdout = devNull
+		cmd.Stderr = devNull
+		defer devNull.Close()
+	}
+
+	if err := cmd.Start(); err != nil {
+		// Another process may have started the server between our health
+		// check and this exec (race).
+		if healthProbe(url) == nil {
+			return nil
+		}
+		return fmt.Errorf("failed to start opencode server: %w", err)
+	}
+	cmd.Process.Release()
+
+	for i := 0; i < 20; i++ {
+		if healthProbe(url) == nil {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("opencode server started but not healthy at %s", url)
+}
+
+// EnsureRemoteServer ensures an OpenCode server is running on the remote host.
+// Requires the SSH tunnel to be up (call ssh.EnsureTunnel first).
+// Health checks go through the tunnel; if the server isn't running, starts it via SSH.
+func EnsureRemoteServer(host string) error {
+	tunnelURL := fmt.Sprintf("http://localhost:%d", TunnelPort())
+
+	if healthProbe(tunnelURL) == nil {
+		return nil
+	}
+
+	port := ServerPort()
+	startCmd := fmt.Sprintf("nohup opencode serve --port %d >/dev/null 2>&1 &", port)
+	if _, err := ssh.Run(host, startCmd); err != nil {
+		// Race — someone else may have started it.
+		if healthProbe(tunnelURL) == nil {
+			return nil
+		}
+		return fmt.Errorf("failed to start remote opencode server: %w", err)
+	}
+
+	for i := 0; i < 20; i++ {
+		if healthProbe(tunnelURL) == nil {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("remote opencode server started but not healthy through tunnel at %s", tunnelURL)
+}
+
+// healthProbe checks whether the OpenCode server is reachable with a short timeout.
+func healthProbe(serverURL string) error {
+	resp, err := httpGetTimeout(serverURL+"/global/health", 500*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"sort"
 	"time"
 
@@ -38,14 +37,13 @@ type message struct {
 
 // LocalServerURL returns the local OpenCode server URL.
 func LocalServerURL() string {
-	if u := os.Getenv("WT_LOCAL_SERVER"); u != "" {
-		return u
-	}
-	return "http://localhost:4096"
+	return fmt.Sprintf("http://localhost:%d", ServerPort())
 }
 
-// RemoteServerURL is the remote OpenCode server, always reached through the SSH tunnel.
-const RemoteServerURL = "http://localhost:4097"
+// RemoteServerURL returns the remote OpenCode server URL (through the SSH tunnel).
+func RemoteServerURL() string {
+	return fmt.Sprintf("http://localhost:%d", TunnelPort())
+}
 
 // CheckHealth verifies that the OpenCode server is reachable.
 func CheckHealth(serverURL string) error {

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -10,9 +10,6 @@ import (
 	"time"
 )
 
-// TunnelPort is the local port for the SSH tunnel to the remote OpenCode server.
-const TunnelPort = 4097
-
 // Host returns WT_REMOTE_HOST or an error if unset.
 func Host() (string, error) {
 	host := os.Getenv("WT_REMOTE_HOST")
@@ -72,36 +69,36 @@ func ToRemotePath(localPath, remoteHome string) (string, error) {
 	return remoteHome + localPath[len(home):], nil
 }
 
-// EnsureTunnel ensures an SSH tunnel from localhost:4097 to the remote host's
-// port 4096 is running. If the tunnel is already up, this is a no-op. Otherwise,
-// starts ssh -fNL 4097:localhost:4096 <host> and waits for it to come up.
-// The tunnel is long-lived and shared across wt invocations.
-func EnsureTunnel(host string) error {
-	if tunnelHealthy() {
+// EnsureTunnel ensures an SSH tunnel from localhost:<localPort> to the remote
+// host's <remotePort> is running. If the tunnel is already up, this is a no-op.
+// Otherwise, starts ssh -fNL <localPort>:localhost:<remotePort> <host> and waits
+// for it to come up. The tunnel is long-lived and shared across wt invocations.
+func EnsureTunnel(host string, localPort, remotePort int) error {
+	if tunnelHealthy(localPort) {
 		return nil
 	}
-	cmd := exec.Command("ssh", "-fNL", fmt.Sprintf("%d:localhost:4096", TunnelPort), host)
+	cmd := exec.Command("ssh", "-fNL", fmt.Sprintf("%d:localhost:%d", localPort, remotePort), host)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Another process may have started the tunnel between our health
 		// check and this SSH invocation (race on "address already in use").
-		if tunnelHealthy() {
+		if tunnelHealthy(localPort) {
 			return nil
 		}
 		return fmt.Errorf("failed to start SSH tunnel to %s: %w: %s", host, err, strings.TrimSpace(string(out)))
 	}
 	// Wait for the tunnel to accept connections.
 	for i := 0; i < 20; i++ {
-		if tunnelHealthy() {
+		if tunnelHealthy(localPort) {
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	return fmt.Errorf("SSH tunnel started but localhost:%d not reachable", TunnelPort)
+	return fmt.Errorf("SSH tunnel started but localhost:%d not reachable", localPort)
 }
 
-// tunnelHealthy checks whether the tunnel port is accepting TCP connections.
-func tunnelHealthy() bool {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", TunnelPort), 500*time.Millisecond)
+// tunnelHealthy checks whether the given port is accepting TCP connections.
+func tunnelHealthy(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 500*time.Millisecond)
 	if err != nil {
 		return false
 	}

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestTunnelHealthy_NoListener(t *testing.T) {
 	// With nothing listening on the tunnel port, tunnelHealthy should return false.
 	// This validates the TCP probe without requiring an SSH host.
-	if tunnelHealthy() {
+	if tunnelHealthy(5097) {
 		t.Skip("something is already listening on the tunnel port")
 	}
 }
@@ -14,7 +14,7 @@ func TestEnsureTunnel_BadHost(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
-	err := EnsureTunnel("wt-nonexistent-host-test")
+	err := EnsureTunnel("wt-nonexistent-host-test", 5097, 5096)
 	if err == nil {
 		t.Fatal("expected error for unreachable host")
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -43,13 +43,14 @@ func mustCwd() string {
 }
 
 type testEnv struct {
-	t         *testing.T
-	rootDir   string
-	dataDir   string
-	repo      string
-	mockURL   string
-	sessions  []mockSession
-	sessionMu sync.Mutex
+	t          *testing.T
+	rootDir    string
+	dataDir    string
+	repo       string
+	mockURL    string
+	mockPort   string
+	sessions   []mockSession
+	sessionMu  sync.Mutex
 }
 
 type mockSession struct {
@@ -182,6 +183,8 @@ func (e *testEnv) startMockServer() {
 	go srv.Serve(ln)
 	e.t.Cleanup(func() { srv.Close() })
 	e.mockURL = "http://" + ln.Addr().String()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	e.mockPort = port
 }
 
 func (e *testEnv) wt(args ...string) string {
@@ -190,7 +193,7 @@ func (e *testEnv) wt(args ...string) string {
 	cmd.Dir = e.repo
 	cmd.Env = append(os.Environ(),
 		"WT_REMOTE_HOST=",
-		"WT_LOCAL_SERVER="+e.mockURL,
+		"WT_OPENCODE_PORT="+e.mockPort,
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil && !strings.Contains(string(out), "cannot remove") {


### PR DESCRIPTION
## Summary

- wt now auto-starts OpenCode servers using the same ensure pattern as the SSH tunnel: health-check, start if needed, poll until ready, reuse across invocations
- Port scheme: server on 5096, tunnel on 5097 (server+1), overridable via `WT_SERVER_PORT`
- Removes `WT_LOCAL_SERVER`/`WT_REMOTE_SERVER` env vars and external server management as a prerequisite

Closes #18