### PR TITLE
Simplify rm: targeted rm just removes, batch rm protects git state

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -122,7 +122,9 @@ Create or resume a worktree.
 
 - No args: pull the current branch to ensure the worktree starts from the
   latest remote state. Create a new worktree. Attach.
-- With `name`: resume `<repo>/.worktrees/<name>`. Attach.
+- With `name`: pull the repo's default branch (best-effort) to keep it fresh
+  for future worktree creation and merge detection. Resume
+  `<repo>/.worktrees/<name>`. Attach.
 
 ### `wt -r <path>`
 
@@ -148,31 +150,34 @@ All attach operations follow the same steps:
 If no session exists for the worktree, `opencode attach` is run without
 `--session`. OpenCode creates a new session on first prompt.
 
-### `wt rm [name] [--force] [--stale N] [--dry-run]`
+### `wt rm [name] [--dry-run]`
 
-Remove worktrees that are safe to clean up.
+Remove worktrees.
 
-A worktree is safe to remove when there is nothing left to lose and no reason
-to come back.
+**Targeted** (`wt rm <name>`): removes the worktree unconditionally.
+Force-deletes the worktree directory and branch. The user already knows the
+state from `wt ls` or `wt rm --dry-run`.
 
-**Nothing left to lose** — working tree is clean, no unpushed commits, and
-agent is not actively generating.
+**Batch** (`wt rm`): removes worktrees that are safe to clean up. A worktree is
+safe when there is no at-risk git state (clean working tree, no commits not on
+the default branch). Classification:
 
-**No reason to come back** — branch is merged, no session exists, or session
-is stale (inactive longer than `--stale` threshold, default 12 hours) with no
-commits on the branch. Squash merges cannot be safely detected because the
-commit hash has changed. These worktrees are removed when stale or by targeted
-`wt rm <name>`.
+| Action | Label | Meaning |
+|--------|-------|---------|
+| remove | `empty` | No session was ever created |
+| remove | `merged` | Branch tip is ancestor of `origin/<default>` |
+| remove | `stale` | Session inactive >12 hours, no unique commits |
+| keep | `dirty` | Uncommitted changes in working tree |
+| keep | `committed` | Unique commits not merged into default branch |
+| keep | `active` | Session exists, not stale, no unique commits |
 
-- No args: batch mode. Requires both. Print what was removed and skipped.
-- With `name`: targeted mode. Requires nothing left to lose; warns about
-  reason to come back.
-- `--stale N`: override the stale threshold (default 12 hours).
-- `--dry-run`: preview without removing.
-- `--force`: skip all checks.
+Squash merges cannot be detected because the commit hash changes. These
+worktrees are removed when stale or by targeted `wt rm <name>`.
 
-Fetches from origin before checking. Removal deletes the worktree directory
-and the branch. Session history in the database is not touched.
+- `--dry-run`: preview classification without removing.
+
+Batch rm fetches from origin before classifying. Removal deletes the worktree
+directory and the branch. Session history in the database is not touched.
 
 ### `wt ls`
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"sort"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -75,7 +74,6 @@ func cmdLocal(args []string) {
 		if err := git.WorktreeAdd("", repo, name); err != nil {
 			die("failed to create worktree: %v", err)
 		}
-		fmt.Printf("wt %s\n", name)
 		if err := attach(serverURL, wtDir, ""); err != nil {
 			die("%v", err)
 		}
@@ -94,6 +92,14 @@ func cmdLocal(args []string) {
 	if !ok {
 		die("worktree %q not found", name)
 	}
+
+	// Pull the repo's default branch to keep it fresh for new worktrees
+	// and merge detection. Best-effort — warn and continue on failure.
+	host := hostFor(entry)
+	if err := git.Pull(host, entry.Repo); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: pull failed: %v\n", err)
+	}
+
 	if !entry.Remote {
 		sessionID := opencode.FindLatestSession(serverURL, entry.Dir)
 		if err := attach(serverURL, entry.Dir, sessionID); err != nil {
@@ -153,8 +159,6 @@ func cmdRemote(args []string) {
 	if err := git.WorktreeAdd(host, repo, name); err != nil {
 		die("failed to create remote worktree: %v", err)
 	}
-	fmt.Printf("wt %s\n", name)
-
 	if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
 		die("%v", err)
 	}
@@ -234,29 +238,15 @@ func cmdLs(remoteOnly bool) {
 	display.PrintTable(rows)
 }
 
-// cmdRm handles: wt rm [name] [--force] [--stale N] [--dry-run]
+// cmdRm handles: wt rm [name] [--dry-run]
 func cmdRm(args []string, remoteOnly bool) {
 	var name string
-	force := false
 	dryRun := false
-	staleHours := 12
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
-		case "--force":
-			force = true
 		case "--dry-run":
 			dryRun = true
-		case "--stale":
-			if i+1 >= len(args) {
-				die("--stale requires a number of hours")
-			}
-			n, err := strconv.Atoi(args[i+1])
-			if err != nil {
-				die("--stale requires a number of hours")
-			}
-			staleHours = n
-			i++
 		default:
 			if name != "" {
 				die("unexpected argument: %s", args[i])
@@ -266,9 +256,9 @@ func cmdRm(args []string, remoteOnly bool) {
 	}
 
 	if name != "" {
-		cmdRmTargeted(name, remoteOnly, force, dryRun)
+		cmdRmTargeted(name)
 	} else {
-		cmdRmBatch(remoteOnly, time.Duration(staleHours)*time.Hour, dryRun)
+		cmdRmBatch(remoteOnly, dryRun)
 	}
 }
 
@@ -352,84 +342,30 @@ func fetchRepos(entries []worktree.Entry) {
 	}
 }
 
-// checkDataSafety checks the three data safety gates. Returns a list of reasons
-// the worktree is NOT safe to remove. Empty list means data-safe.
-func checkDataSafety(e worktree.Entry) []string {
-	host := hostFor(e)
-	var reasons []string
-
-	if e.Status == "working" {
-		reasons = append(reasons, "agent is working")
-	}
-	if !git.IsClean(host, e.Dir) {
-		reasons = append(reasons, "uncommitted changes")
-	}
-	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
-	if unique > 0 && !git.IsPushed(host, e.Repo, e.Name) {
-		reasons = append(reasons, fmt.Sprintf("%d unpushed commit(s)", unique))
-	}
-
-	return reasons
-}
-
-// checkWorkflowDone checks whether there's no reason to come back to this
-// worktree. Returns true if at least one workflow gate passes.
-func checkWorkflowDone(e worktree.Entry, staleThreshold time.Duration) bool {
-	host := hostFor(e)
-
-	// No session — worktree was never used
-	if e.SessionID == "" {
-		return true
-	}
-
-	// Branch merged — work has landed
-	if git.IsMerged(host, e.Repo, e.Name) {
-		return true
-	}
-
-	// Session stale + no unique commits — started, never committed, walked away
-	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
-	if unique == 0 && !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > staleThreshold {
-		return true
-	}
-
-	return false
-}
-
-// workflowSkipReason returns a human-readable reason why the worktree is not
-// considered done. Only called when checkWorkflowDone returns false.
-func workflowSkipReason(e worktree.Entry) string {
-	host := hostFor(e)
-	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
-	if unique > 0 {
-		return "branch not merged"
-	}
-	return "session active"
-}
+// staleThreshold is the duration after which a session with no unique commits
+// is considered abandoned and safe to remove.
+const staleThreshold = 12 * time.Hour
 
 // classifyForRm determines the action (remove/keep) and reason for a worktree.
-func classifyForRm(e worktree.Entry, staleThreshold time.Duration) (action, reason string) {
+func classifyForRm(e worktree.Entry) (action, reason string) {
 	host := hostFor(e)
 
-	// Data safety gates — accumulate all reasons
+	// Data safety — keep worktrees with at-risk changes
 	var keepReasons []string
-	if e.Status == "working" {
-		keepReasons = append(keepReasons, "working")
-	}
 	if !git.IsClean(host, e.Dir) {
 		keepReasons = append(keepReasons, "dirty")
 	}
 	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
-	if unique > 0 && !git.IsPushed(host, e.Repo, e.Name) {
-		keepReasons = append(keepReasons, "unpushed")
+	if unique > 0 && !git.IsMerged(host, e.Repo, e.Name) {
+		keepReasons = append(keepReasons, "committed")
 	}
 	if len(keepReasons) > 0 {
 		return "keep", strings.Join(keepReasons, ", ")
 	}
 
-	// Workflow gates — determine if work is done
+	// Safe to remove — determine why
 	if e.SessionID == "" {
-		return "remove", "unused"
+		return "remove", "empty"
 	}
 	if git.IsMerged(host, e.Repo, e.Name) {
 		return "remove", "merged"
@@ -438,14 +374,11 @@ func classifyForRm(e worktree.Entry, staleThreshold time.Duration) (action, reas
 		return "remove", "stale"
 	}
 
-	// Not done
-	if unique > 0 {
-		return "keep", "review"
-	}
+	// Not done — session active, no commits yet
 	return "keep", "active"
 }
 
-func cmdRmBatch(remoteOnly bool, staleThreshold time.Duration, dryRun bool) {
+func cmdRmBatch(remoteOnly bool, dryRun bool) {
 	all, enrichErr := discoverAll(remoteOnly)
 	if enrichErr != nil {
 		die("cannot determine session status: %v", enrichErr)
@@ -466,7 +399,7 @@ func cmdRmBatch(remoteOnly bool, staleThreshold time.Duration, dryRun bool) {
 	var removeCount int
 
 	for _, e := range all {
-		action, reason := classifyForRm(e, staleThreshold)
+		action, reason := classifyForRm(e)
 
 		// Actually remove if not dry-run
 		if action == "remove" && !dryRun {
@@ -521,69 +454,18 @@ func cmdRmBatch(remoteOnly bool, staleThreshold time.Duration, dryRun bool) {
 	}
 }
 
-func cmdRmTargeted(name string, remoteOnly bool, force bool, dryRun bool) {
-	all, enrichErr := discoverAll(remoteOnly)
-
-	var entry *worktree.Entry
-	for i := range all {
-		if all[i].Name == name {
-			entry = &all[i]
-			break
-		}
-	}
-	if entry == nil {
+func cmdRmTargeted(name string) {
+	entry, ok := findWorktree(name)
+	if !ok {
 		die("worktree %q not found", name)
 	}
-
-	host := hostFor(*entry)
-
-	if force {
-		action := "remove"
-		if !dryRun {
-			if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
-				die("%v", err)
-			}
-			action = "removed"
-		}
-		display.PrintTable([]display.Row{{
-			Entry:  *entry,
-			Status: fmt.Sprintf("%s (forced)", action),
-		}})
-		return
-	}
-
-	if enrichErr != nil {
-		die("cannot determine session status: %v\n\nUse --force to override.", enrichErr)
-	}
-
-	// Fetch to ensure remote refs are current for safety checks
-	git.Fetch(host, entry.Repo)
-
-	// Data safety gates — hard block
-	if reasons := checkDataSafety(*entry); len(reasons) > 0 {
-		fmt.Fprintf(os.Stderr, "wt: cannot remove %s:\n", name)
-		for _, r := range reasons {
-			fmt.Fprintf(os.Stderr, "  - %s\n", r)
-		}
-		fmt.Fprintf(os.Stderr, "\nUse --force to override.\n")
-		os.Exit(1)
-	}
-
-	// Workflow gates — warnings only
-	if !checkWorkflowDone(*entry, 0) {
-		fmt.Fprintf(os.Stderr, "warning: %s\n", workflowSkipReason(*entry))
-	}
-
-	action, reason := classifyForRm(*entry, 0)
-	if !dryRun {
-		if err := git.WorktreeRemove(host, entry.Repo, entry.Name); err != nil {
-			die("%v", err)
-		}
-		action = "removed"
+	host := hostFor(entry)
+	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
+		die("%v", err)
 	}
 	display.PrintTable([]display.Row{{
-		Entry:  *entry,
-		Status: fmt.Sprintf("%s (%s)", action, reason),
+		Entry:  entry,
+		Status: "removed",
 	}})
 }
 
@@ -599,9 +481,7 @@ Usage:
   wt -r ls                  List remote worktrees only
   wt rm                     Remove all safe-to-remove worktrees
   wt rm --dry-run           Preview what would be removed
-  wt rm <name>              Remove a specific worktree (with safety checks)
-  wt rm <name> --force      Remove a specific worktree (skip all checks)
-  wt rm --stale 1           Remove safe worktrees (1-hour stale threshold)
+  wt rm <name>              Remove a specific worktree
 
 Flags:
   -r, --remote              Operate on the remote dev desktop

--- a/pkg/opencode/attach.go
+++ b/pkg/opencode/attach.go
@@ -5,29 +5,19 @@ import (
 	"strings"
 )
 
-// AttachedDirs returns a map of worktree directories to the number of
-// opencode TUI clients connected to them. Detection is based on scanning
-// local "opencode attach --dir <path>" processes.
-func AttachedDirs() map[string]int {
+// AttachedDirs returns the set of worktree directories that have an
+// opencode TUI client attached, detected by scanning local
+// "opencode attach --dir <path>" processes.
+func AttachedDirs() map[string]bool {
 	out, err := exec.Command("ps", "-eo", "args").Output()
 	if err != nil {
-		return map[string]int{}
+		return map[string]bool{}
 	}
 
-	result := make(map[string]int)
+	result := make(map[string]bool)
 	for _, line := range strings.Split(string(out), "\n") {
-		dir := parseAttachDir(line)
-		if dir != "" {
-			result[dir]++
-		}
-	}
-
-	// Each attach shows up twice in ps (node wrapper + binary).
-	// Normalize to actual client count.
-	for dir := range result {
-		result[dir] = result[dir] / 2
-		if result[dir] == 0 {
-			result[dir] = 1
+		if dir := parseAttachDir(line); dir != "" {
+			result[dir] = true
 		}
 	}
 	return result

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -28,12 +28,9 @@ func TestAttachedDirs(t *testing.T) {
 
 	// If there are any opencode attach processes running, verify they
 	// have real directory paths.
-	for dir, count := range dirs {
+	for dir := range dirs {
 		if dir == "" {
 			t.Error("empty directory in AttachedDirs result")
-		}
-		if count < 1 {
-			t.Errorf("expected count >= 1 for %s, got %d", dir, count)
 		}
 	}
 }

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -112,7 +112,7 @@ func Enrich(serverURL string, entries []worktree.Entry) error {
 	// Detect locally attached TUI clients.
 	attached := AttachedDirs()
 	for i := range entries {
-		if count, ok := attached[entries[i].Dir]; ok && count > 0 {
+		if attached[entries[i].Dir] {
 			entries[i].Attached = true
 		}
 	}

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -14,6 +14,9 @@ func TestEnsureTunnel_BadHost(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
+	if tunnelHealthy(5097) {
+		t.Skip("tunnel port already in use; cannot test bad-host path")
+	}
 	err := EnsureTunnel("wt-nonexistent-host-test", 5097, 5096)
 	if err == nil {
 		t.Fatal("expected error for unreachable host")

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -196,7 +196,7 @@ func (e *testEnv) wt(args ...string) string {
 		"WT_OPENCODE_PORT="+e.mockPort,
 	)
 	out, err := cmd.CombinedOutput()
-	if err != nil && !strings.Contains(string(out), "cannot remove") {
+	if err != nil {
 		e.t.Logf("wt %v: %v\n%s", args, err, out)
 	}
 	return string(out)
@@ -227,9 +227,9 @@ func assertContains(t *testing.T, output, substring string) {
 	}
 }
 
-// --- Data safety tests ---
+// --- Targeted rm tests (always removes) ---
 
-func TestTargetedRm_DirtyBlocked(t *testing.T) {
+func TestTargetedRm_Dirty(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
 	}
@@ -239,14 +239,13 @@ func TestTargetedRm_DirtyBlocked(t *testing.T) {
 	os.WriteFile(filepath.Join(wt, "f.txt"), []byte("x"), 0644)
 
 	out := env.wt("rm", "dirty")
-	assertContains(t, out, "cannot remove")
-	assertContains(t, out, "uncommitted changes")
-	if !env.worktreeExists("dirty") {
-		t.Error("dirty worktree should NOT have been removed")
+	assertContains(t, out, "removed")
+	if env.worktreeExists("dirty") {
+		t.Error("targeted rm should remove dirty worktree")
 	}
 }
 
-func TestTargetedRm_UnpushedBlocked(t *testing.T) {
+func TestTargetedRm_Unmerged(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
 	}
@@ -256,45 +255,9 @@ func TestTargetedRm_UnpushedBlocked(t *testing.T) {
 	env.commitFile(wt, "a.txt", "a", "local work")
 
 	out := env.wt("rm", "unpushed")
-	assertContains(t, out, "cannot remove")
-	assertContains(t, out, "unpushed commit")
-	if !env.worktreeExists("unpushed") {
-		t.Error("unpushed worktree should NOT have been removed")
-	}
-}
-
-func TestTargetedRm_AgentWorkingBlocked(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping e2e test")
-	}
-	t.Parallel()
-	env := newTestEnv(t)
-	wt := env.addWorktree("working")
-	// A just-created session is "working" (assistant message < 60s old)
-	env.createSession(wt)
-
-	out := env.wt("rm", "working")
-	assertContains(t, out, "cannot remove")
-	assertContains(t, out, "agent is working")
-	if !env.worktreeExists("working") {
-		t.Error("worktree with working agent should NOT have been removed")
-	}
-}
-
-func TestTargetedRm_ForceOverrides(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping e2e test")
-	}
-	t.Parallel()
-	env := newTestEnv(t)
-	wt := env.addWorktree("force")
-	os.WriteFile(filepath.Join(wt, "f.txt"), []byte("x"), 0644)
-
-	out := env.wt("rm", "force", "--force")
-	assertContains(t, out, "force")
-	assertContains(t, out, "removed (forced)")
-	if env.worktreeExists("force") {
-		t.Error("worktree should have been removed with --force")
+	assertContains(t, out, "removed")
+	if env.worktreeExists("unpushed") {
+		t.Error("targeted rm should remove unmerged worktree")
 	}
 }
 
@@ -310,7 +273,7 @@ func TestTargetedRm_CleanNoSession(t *testing.T) {
 
 	out := env.wt("rm", "clean")
 	assertContains(t, out, "clean")
-	assertContains(t, out, "removed (")
+	assertContains(t, out, "removed")
 	if env.worktreeExists("clean") {
 		t.Error("clean no-session worktree should have been removed")
 	}
@@ -329,13 +292,13 @@ func TestTargetedRm_MergedBranch(t *testing.T) {
 
 	out := env.wt("rm", "merged")
 	assertContains(t, out, "merged")
-	assertContains(t, out, "removed (")
+	assertContains(t, out, "removed")
 	if env.worktreeExists("merged") {
 		t.Error("merged worktree should have been removed")
 	}
 }
 
-func TestTargetedRm_PushedNotMergedWarns(t *testing.T) {
+func TestTargetedRm_PushedUnmerged(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
 	}
@@ -344,14 +307,11 @@ func TestTargetedRm_PushedNotMergedWarns(t *testing.T) {
 	wt := env.addWorktree("in-review")
 	env.commitFile(wt, "f.txt", "wip", "work")
 	env.push("in-review")
-	// No session → "no session" gate fires, no warning expected
-	// (workflow warning only appears when a session blocks the gate)
 
 	out := env.wt("rm", "in-review")
-	assertContains(t, out, "in-review")
-	assertContains(t, out, "removed (")
+	assertContains(t, out, "removed")
 	if env.worktreeExists("in-review") {
-		t.Error("pushed worktree should have been removed in targeted mode")
+		t.Error("targeted rm should remove pushed unmerged worktree")
 	}
 }
 
@@ -392,7 +352,7 @@ func TestBatchRm_DryRun(t *testing.T) {
 	assertContains(t, out, "batch-dirty")
 	assertContains(t, out, "keep (dirty")
 	assertContains(t, out, "batch-unpushed")
-	assertContains(t, out, "keep (unpushed")
+	assertContains(t, out, "keep (committed")
 
 	// Nothing actually removed
 	for _, name := range []string{"batch-clean", "batch-merged", "batch-dirty", "batch-unpushed"} {
@@ -402,21 +362,21 @@ func TestBatchRm_DryRun(t *testing.T) {
 	}
 }
 
-func TestBatchRm_SessionWorkingSkipped(t *testing.T) {
+func TestBatchRm_SessionActiveSkipped(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
 	}
 	t.Parallel()
 	env := newTestEnv(t)
-	wt := env.addWorktree("batch-working")
+	wt := env.addWorktree("batch-active")
 	env.createSession(wt)
 
 	out := env.wt("rm", "--dry-run")
 	t.Log("output:\n" + out)
 
-	// Just-created session is "working" (< 60s) — data gate blocks
-	assertContains(t, out, "batch-working")
-	assertContains(t, out, "keep (working)")
+	// Session is recent with no commits — kept as active
+	assertContains(t, out, "batch-active")
+	assertContains(t, out, "keep (active)")
 }
 
 // --- Remote host configuration tests ---

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -102,7 +102,7 @@ func (e *sshTestEnv) wt(args ...string) string {
 		"XDG_DATA_HOME="+e.dataDir, // remote data dir — wt queries it over SSH
 	)
 	out, err := cmd.CombinedOutput()
-	if err != nil && !strings.Contains(string(out), "cannot remove") {
+	if err != nil {
 		e.t.Logf("wt %v: %v\n%s", args, err, out)
 	}
 	return string(out)


### PR DESCRIPTION
## Summary

Simplifies the rm model:

- **Targeted rm** (`wt rm <name>`) always force-removes. No safety gates, no `--force` flag. User already knows the state from `ls` or `--dry-run`.
- **Batch rm** (`wt rm`) only protects git state: `dirty` (uncommitted changes) and `committed` (unmerged commits). Session status (working/idle) no longer affects rm decisions.
- Remove `--force` and `--stale` flags. Stale threshold hardcoded to 12h.
- Collapse `unpushed`/`review` labels into `committed` (`IsMerged` replaces `IsPushed`)
- Rename `unused` → `empty`
- Simplify `AttachedDirs` to `map[string]bool`, drop `/2` node-wrapper hack
- Pull repo default branch on reattach to keep refs fresh
- Remove redundant `wt <name>` echo (exit row covers it)

Closes #22, closes #23, closes #26