### PR TITLE
Fix token display to show context window size, not cumulative sum

### DIFF
--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -1,6 +1,9 @@
 package opencode
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -80,5 +83,77 @@ func TestParseAttachDir(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.wantDir)
 			}
 		})
+	}
+}
+
+// TestFetchSessionTokens_RegressionContextWindow verifies that fetchSessionTokens
+// returns the last assistant message's total (context window size), not the sum
+// across all messages. Summing double-counts input context that is re-sent each turn.
+func TestFetchSessionTokens_RegressionContextWindow(t *testing.T) {
+	messages := []message{
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "user"}},
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "assistant", Tokens: struct {
+			Total int `json:"total"`
+		}{Total: 25000}}},
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "user"}},
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "assistant", Tokens: struct {
+			Total int `json:"total"`
+		}{Total: 50000}}},
+		// Trailing zero-total message (incomplete/streaming).
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "assistant", Tokens: struct {
+			Total int `json:"total"`
+		}{Total: 0}}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(messages)
+	}))
+	defer srv.Close()
+
+	got := fetchSessionTokens(srv.URL, "test-session")
+
+	// Must return 50000 (last non-zero assistant total), not 75000 (sum).
+	if got != 50000 {
+		t.Errorf("fetchSessionTokens = %d, want 50000 (context window size, not sum)", got)
 	}
 }

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -143,9 +143,10 @@ func listSessions(serverURL, directory string) []Session {
 	return sessions
 }
 
-// fetchSessionTokens returns the total tokens used across all assistant messages
-// in a session. Also returns whether the session is actively streaming (last
-// assistant message has no completion time).
+// fetchSessionTokens returns the context window size for the session — the
+// total tokens from the last assistant message. Each message's Total field
+// represents the full context for that API call (input + output + cache), so
+// the last message gives the current context window usage.
 func fetchSessionTokens(serverURL, sessionID string) int {
 	resp, err := httpGet(serverURL + "/session/" + sessionID + "/message")
 	if err != nil {
@@ -158,13 +159,13 @@ func fetchSessionTokens(serverURL, sessionID string) int {
 		return 0
 	}
 
-	var total int
-	for _, m := range messages {
-		if m.Info.Role == "assistant" {
-			total += m.Info.Tokens.Total
+	// Walk backwards to find the last assistant message with a non-zero total.
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Info.Role == "assistant" && messages[i].Info.Tokens.Total > 0 {
+			return messages[i].Info.Tokens.Total
 		}
 	}
-	return total
+	return 0
 }
 
 func httpGet(u string) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- **Bug**: `fetchSessionTokens` summed `tokens.total` across all assistant messages. Each message's `total` includes the full context window (input + output + cache), so summing re-counts the context every turn — inflating e.g. 94k of real context to 3.5M+.
- **Fix**: Return the last assistant message's `total` instead, which is the actual context window size.
- **Test**: Regression test with httptest server verifies the function returns the last message's total (50k), not the sum (75k).

## Before/After

| Metric | Before | After |
|--------|--------|-------|
| Session with 94k context | 3.5M+ (sum of all turns) | 94k (context window size) |