### PR TITLE
Fix remote opencode server start by using interactive shell for PATH

### DIFF
--- a/pkg/opencode/server.go
+++ b/pkg/opencode/server.go
@@ -81,7 +81,7 @@ func EnsureRemoteServer(host string) error {
 	}
 
 	port := ServerPort()
-	startCmd := fmt.Sprintf("nohup opencode serve --port %d >/dev/null 2>&1 &", port)
+	startCmd := fmt.Sprintf("$SHELL -ic 'nohup opencode serve --port %d </dev/null >/dev/null 2>&1 &'", port)
 	if _, err := ssh.Run(host, startCmd); err != nil {
 		// Race — someone else may have started it.
 		if healthProbe(tunnelURL) == nil {


### PR DESCRIPTION
## Summary
- `ssh.Run` pipes commands to non-interactive bash with minimal PATH (`/usr/local/bin:/usr/bin`). `opencode` installed at `~/.opencode/bin` is only in PATH via `.zshrc`/`.bashrc` (interactive shells). The `nohup opencode serve` command silently failed with `command not found`.
- Wrap the server start command in `$SHELL -ic '...'` so it runs through the user's interactive shell with the full PATH.
- Also redirect stdin from `/dev/null` to prevent the background process from holding the SSH channel's stdin FD open.

## Testing
- Reproduced the bug: `wt -r ~/go/src/github.com/kubernetes-sigs/kro` → `remote opencode server started but not healthy through tunnel`
- Verified root cause: `ssh host bash <<< 'which opencode'` → `command not found`, PATH is `/usr/local/bin:/usr/bin`
- Verified fix: clean state → `wt -r` launches TUI successfully, server running on remote port 5096, health 200 through tunnel
- Verified idempotency: second `wt -r` reuses existing server and tunnel
- Verified `wt ls` shows remote sessions with status enrichment
- Verified `wt ls` warning on stale tunnel
- All unit tests pass; pre-existing e2e test failure in `TestSSH_BatchRm_DryRun` (unrelated output format mismatch)