### PR TITLE
Detect squash merges in wt rm using merge-tree simulation

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -165,14 +165,16 @@ the default branch). Classification:
 | Action | Label | Meaning |
 |--------|-------|---------|
 | remove | `empty` | No session was ever created |
-| remove | `merged` | Branch tip is ancestor of `origin/<default>` |
+| remove | `merged` | Changes incorporated into `origin/<default>` (regular, fast-forward, or squash merge) |
 | remove | `stale` | Session inactive >12 hours, no unique commits |
 | keep | `dirty` | Uncommitted changes in working tree |
 | keep | `committed` | Unique commits not merged into default branch |
 | keep | `active` | Session exists, not stale, no unique commits |
 
-Squash merges cannot be detected because the commit hash changes. These
-worktrees are removed when stale or by targeted `wt rm <name>`.
+Squash merges are detected using `git merge-tree --write-tree` (requires git
+2.38+): if simulating a merge of the branch into `origin/<default>` produces a
+tree identical to the target's current tree, the branch's changes are already
+incorporated.
 
 - `--dry-run`: preview classification without removing.
 

--- a/main.go
+++ b/main.go
@@ -356,7 +356,8 @@ func classifyForRm(e worktree.Entry) (action, reason string) {
 		keepReasons = append(keepReasons, "dirty")
 	}
 	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
-	if unique > 0 && !git.IsMerged(host, e.Repo, e.Name) {
+	merged := git.IsMerged(host, e.Repo, e.Name)
+	if unique > 0 && !merged {
 		keepReasons = append(keepReasons, "committed")
 	}
 	if len(keepReasons) > 0 {
@@ -367,7 +368,7 @@ func classifyForRm(e worktree.Entry) (action, reason string) {
 	if e.SessionID == "" {
 		return "remove", "empty"
 	}
-	if git.IsMerged(host, e.Repo, e.Name) {
+	if merged {
 		return "remove", "merged"
 	}
 	if unique == 0 && !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > staleThreshold {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -108,21 +108,42 @@ func UniqueCommitCount(host, repo, branch string) int {
 	return n
 }
 
-// IsMerged returns true if the branch was pushed to origin and its tip is now
-// an ancestor of origin/<default>. A branch that was never pushed cannot be
+// IsMerged returns true if the branch was pushed to origin and its changes are
+// incorporated into origin/<default>. A branch that was never pushed cannot be
 // "merged" — it's either fresh or was only worked on locally.
 //
-// This catches regular merges and fast-forward merges (GitFarm). Squash merges
-// produce a new commit hash on main, so the branch tip is not an ancestor —
-// those are not detected and rely on the stale gate or targeted removal.
+// Detection is two-phase:
+//  1. Ancestry check — catches regular merges and fast-forward merges.
+//  2. Merge-tree simulation — catches squash merges. Simulates merging the
+//     branch into origin/<default> and checks whether the result tree is
+//     identical to origin/<default>'s tree (i.e., the branch adds nothing new).
+//     Requires git 2.38+.
 func IsMerged(host, repo, branch string) bool {
 	// A branch that was never pushed can't be "merged."
 	if _, err := runGit(host, repo, "rev-parse", "--verify", "refs/remotes/origin/"+branch); err != nil {
 		return false
 	}
 	def := DefaultBranch(host, repo)
-	_, err := runGit(host, repo, "merge-base", "--is-ancestor", branch, "origin/"+def)
-	return err == nil
+	target := "origin/" + def
+
+	// Fast path: ancestry check (regular merge / fast-forward).
+	if _, err := runGit(host, repo, "merge-base", "--is-ancestor", branch, target); err == nil {
+		return true
+	}
+
+	// Slow path: merge-tree simulation (squash merge).
+	// Simulate merging the branch into the target. If the resulting tree
+	// equals the target's current tree, the branch's diff is a no-op —
+	// its changes are already in the target regardless of commit history.
+	mergeTree, err := runGit(host, repo, "merge-tree", "--write-tree", target, branch)
+	if err != nil {
+		return false // conflict or git too old — not merged
+	}
+	targetTree, err := runGit(host, repo, "rev-parse", target+"^{tree}")
+	if err != nil {
+		return false
+	}
+	return mergeTree == targetTree
 }
 
 // IsClean returns true if the worktree has no modified, staged, or untracked files.

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -125,6 +125,15 @@ func (e *testEnv) mergeToMain(branch string) {
 	gitCmd(e.t, e.repo, "fetch", "origin")
 }
 
+func (e *testEnv) squashMergeToMain(branch string) {
+	e.t.Helper()
+	gitCmd(e.t, e.repo, "checkout", "main")
+	gitCmd(e.t, e.repo, "merge", "--squash", branch)
+	gitCmd(e.t, e.repo, "commit", "-m", "squash merge "+branch)
+	gitCmd(e.t, e.repo, "push", "origin", "main")
+	gitCmd(e.t, e.repo, "fetch", "origin")
+}
+
 func (e *testEnv) createSession(dir string) {
 	e.t.Helper()
 	now := time.Now().UnixMilli()
@@ -334,6 +343,14 @@ func TestBatchRm_DryRun(t *testing.T) {
 	env.mergeToMain("batch-merged")
 	gitCmd(t, env.repo, "checkout", "main")
 
+	// Would remove: squash-merged (with session, so classified as "merged" not "empty")
+	wt5 := env.addWorktree("batch-squashed")
+	env.commitFile(wt5, "g.txt", "squashed", "squash feature")
+	env.push("batch-squashed")
+	env.createSession(wt5)
+	env.squashMergeToMain("batch-squashed")
+	gitCmd(t, env.repo, "checkout", "main")
+
 	// Skipped: dirty
 	wt3 := env.addWorktree("batch-dirty")
 	os.WriteFile(filepath.Join(wt3, "f.txt"), []byte("x"), 0644)
@@ -347,7 +364,15 @@ func TestBatchRm_DryRun(t *testing.T) {
 
 	assertContains(t, out, "batch-clean")
 	assertContains(t, out, "batch-merged")
+	assertContains(t, out, "batch-squashed")
 	assertContains(t, out, "remove (")
+
+	// Squash-merged branch has a session and unique commits, but merge-tree
+	// detection recognizes its changes are in main — classified as "merged".
+	// Without squash detection it would be "keep (committed)".
+	if !strings.Contains(out, "batch-squashed") || !strings.Contains(out, "remove (merged)") {
+		t.Error("squash-merged worktree should be classified as remove (merged)")
+	}
 
 	assertContains(t, out, "batch-dirty")
 	assertContains(t, out, "keep (dirty")
@@ -355,7 +380,7 @@ func TestBatchRm_DryRun(t *testing.T) {
 	assertContains(t, out, "keep (committed")
 
 	// Nothing actually removed
-	for _, name := range []string{"batch-clean", "batch-merged", "batch-dirty", "batch-unpushed"} {
+	for _, name := range []string{"batch-clean", "batch-merged", "batch-squashed", "batch-dirty", "batch-unpushed"} {
 		if !env.worktreeExists(name) {
 			t.Errorf("worktree %q removed during dry-run", name)
 		}


### PR DESCRIPTION
## Summary
- `IsMerged` now falls back to `git merge-tree --write-tree` when the ancestry check fails, detecting squash merges immediately instead of waiting for the 12-hour stale gate.
- If simulating a merge of the branch into `origin/<default>` produces a tree identical to the target's current tree, the branch's changes are already incorporated — regardless of commit history.
- Requires git 2.38+; degrades gracefully on older versions or conflicts.
- Hoisted `IsMerged` call in `classifyForRm` to avoid redundant invocations on the slow path.
- Added e2e test covering squash merge detection with explicit assertion on `remove (merged)`.