### PR TITLE
Add INFO logs for infrastructure setup and propagate session query errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func cmdLocal(args []string) {
 		if err := git.WorktreeAdd("", repo, name); err != nil {
 			die("failed to create worktree: %v", err)
 		}
+		fmt.Fprintf(os.Stderr, "created worktree %s\n", name)
 		if err := attach(serverURL, wtDir, ""); err != nil {
 			die("%v", err)
 		}
@@ -159,6 +160,7 @@ func cmdRemote(args []string) {
 	if err := git.WorktreeAdd(host, repo, name); err != nil {
 		die("failed to create remote worktree: %v", err)
 	}
+	fmt.Fprintf(os.Stderr, "created worktree %s on %s\n", name, host)
 	if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
 		die("%v", err)
 	}
@@ -226,7 +228,7 @@ func cmdLs(remoteOnly bool) {
 		return
 	}
 	if enrichErr != nil {
-		fmt.Fprintf(os.Stderr, "warning: %v\n\n", enrichErr)
+		die("%v", enrichErr)
 	}
 	rows := make([]display.Row, len(all))
 	for i, e := range all {

--- a/pkg/opencode/server.go
+++ b/pkg/opencode/server.go
@@ -63,6 +63,7 @@ func EnsureLocalServer() error {
 
 	for i := 0; i < 20; i++ {
 		if healthProbe(url) == nil {
+			fmt.Fprintf(os.Stderr, "started opencode server on port %d\n", port)
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -92,6 +93,7 @@ func EnsureRemoteServer(host string) error {
 
 	for i := 0; i < 20; i++ {
 		if healthProbe(tunnelURL) == nil {
+			fmt.Fprintf(os.Stderr, "started remote opencode server via %s\n", host)
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -66,9 +66,10 @@ func checkHealthFast(serverURL string) error {
 }
 
 // FindLatestSession queries the OpenCode server for the most recent session
-// in the given directory. Returns empty string if none found or server unreachable.
+// in the given directory. Returns empty string if none found or on error.
+// Best-effort — used for session resumption where failure means a new session.
 func FindLatestSession(serverURL, directory string) string {
-	s := QuerySession(serverURL, directory)
+	s, _ := QuerySession(serverURL, directory)
 	if s == nil {
 		return ""
 	}
@@ -76,13 +77,16 @@ func FindLatestSession(serverURL, directory string) string {
 }
 
 // QuerySession queries the OpenCode server for the most recent session
-// in the given directory. Returns nil if none found or server unreachable.
-func QuerySession(serverURL, directory string) *Session {
-	sessions := listSessions(serverURL, directory)
-	if len(sessions) == 0 {
-		return nil
+// in the given directory. Returns nil if none found.
+func QuerySession(serverURL, directory string) (*Session, error) {
+	sessions, err := listSessions(serverURL, directory)
+	if err != nil {
+		return nil, err
 	}
-	return &sessions[0]
+	if len(sessions) == 0 {
+		return nil, nil
+	}
+	return &sessions[0], nil
 }
 
 // Enrich enriches worktree entries with session data from the OpenCode server.
@@ -93,7 +97,10 @@ func Enrich(serverURL string, entries []worktree.Entry) error {
 	}
 
 	for i := range entries {
-		s := QuerySession(serverURL, entries[i].Dir)
+		s, err := QuerySession(serverURL, entries[i].Dir)
+		if err != nil {
+			return err
+		}
 		if s == nil {
 			continue
 		}
@@ -122,25 +129,25 @@ func Enrich(serverURL string, entries []worktree.Entry) error {
 
 // listSessions fetches sessions from the server, optionally filtered by directory.
 // Returns sessions sorted by most recently updated first.
-func listSessions(serverURL, directory string) []Session {
+func listSessions(serverURL, directory string) ([]Session, error) {
 	u := serverURL + "/session?limit=1000"
 	if directory != "" {
 		u += "&directory=" + url.QueryEscape(directory)
 	}
 	resp, err := httpGet(u)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	var sessions []Session
 	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
-		return nil
+		return nil, fmt.Errorf("decode session response: %w", err)
 	}
 	sort.Slice(sessions, func(i, j int) bool {
 		return sessions[i].Time.Updated > sessions[j].Time.Updated
 	})
-	return sessions
+	return sessions, nil
 }
 
 // fetchSessionTokens returns the context window size for the session — the

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -89,6 +89,7 @@ func EnsureTunnel(host string, localPort, remotePort int) error {
 	// Wait for the tunnel to accept connections.
 	for i := 0; i < 20; i++ {
 		if tunnelHealthy(localPort) {
+			fmt.Fprintf(os.Stderr, "started SSH tunnel to %s (localhost:%d)\n", host, localPort)
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
## Summary

- **INFO logs**: server start, tunnel start, and worktree creation print a
  one-line status message to stderr — only when the tool actually spawned a
  new process, silent when reusing existing infrastructure.
- **Session query error propagation**: `listSessions` returns `([]Session, error)`
  instead of silently returning `nil`. Errors propagate through `QuerySession` →
  `Enrich` → `discoverAll` → `cmdLs`/`cmdRmBatch`, which `die()` rather than
  display incomplete data.
- **`cmdLs` fails on enrichment error** instead of showing a table with missing
  session columns (previously warned and continued).

## What the human sees

```
# Server started (only when spawned, not reused):
started opencode server on port 5096

# Worktree created:
created worktree 0425T1513-33411

# Session query failure (previously silent):
wt: local session query: HTTP 500 from http://localhost:5096/session?...
```

## Files changed

| File | Change |
|---|---|
| `pkg/opencode/server.go` | INFO after starting local/remote server |
| `pkg/ssh/ssh.go` | INFO after starting SSH tunnel |
| `main.go` | INFO after creating worktree; `cmdLs` dies on enrichment error |
| `pkg/opencode/session.go` | `listSessions`/`QuerySession` return errors; `Enrich` fails fast |