### PR TITLE
Fix wt rm table formatting blown out by long error messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -402,6 +402,7 @@ func cmdRmBatch(remoteOnly bool, dryRun bool) {
 		entry  worktree.Entry
 		action string
 		reason string
+		errMsg string
 	}
 	var results []classified
 	var removeCount int
@@ -410,11 +411,13 @@ func cmdRmBatch(remoteOnly bool, dryRun bool) {
 		action, reason := classifyForRm(e)
 
 		// Actually remove if not dry-run
+		var errMsg string
 		if action == "remove" && !dryRun {
 			host := hostFor(e)
 			if err := git.WorktreeRemove(host, e.Repo, e.Name); err != nil {
 				action = "keep"
-				reason = strings.ReplaceAll(strings.TrimSpace(err.Error()), "\n", " ")
+				reason = "error"
+				errMsg = strings.ReplaceAll(strings.TrimSpace(err.Error()), "\n", " ")
 			} else {
 				action = "removed"
 			}
@@ -423,7 +426,7 @@ func cmdRmBatch(remoteOnly bool, dryRun bool) {
 		if action == "remove" || action == "removed" {
 			removeCount++
 		}
-		results = append(results, classified{e, action, reason})
+		results = append(results, classified{e, action, reason, errMsg})
 	}
 
 	// Sort: removes first, then keeps; by activity (newest first) within each group
@@ -455,6 +458,12 @@ func cmdRmBatch(remoteOnly bool, dryRun bool) {
 		}
 	}
 	display.PrintTable(rows)
+
+	for _, r := range results {
+		if r.errMsg != "" {
+			fmt.Fprintf(os.Stderr, "ERROR: %s: %s\n", r.entry.Name, r.errMsg)
+		}
+	}
 
 	if removeCount == 0 {
 		fmt.Println()


### PR DESCRIPTION
## Summary
- Move git removal error messages from the STATUS column to stderr footnotes
- The STATUS cell now shows `keep (error)` instead of the full error string, preventing `tabwriter` from expanding the column to accommodate unbounded git output
- Full error details are still printed below the table as `ERROR: <name>: <message>`