### PR TITLE
Unify status vocabulary: replace 'active' with idle/working/stale

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -28,8 +28,10 @@ and full message history. A worktree can have multiple sessions; the most recent
 is attached by default. Session lifecycle (creating new sessions, forking) is
 managed from within OpenCode, not by this tool.
 
-A session is **working** when the agent is actively generating a response, and
-**idle** otherwise. A worktree with no session has no status.
+A session is **working** when the agent is actively generating a response,
+**idle** when the session exists but is not generating, and **stale** when the
+session has been idle for more than 12 hours. A worktree with no session has no
+status.
 
 An **OpenCode server** is a persistent process running `opencode serve`. One
 server hosts all worktrees across all repos. Every API endpoint accepts a
@@ -169,7 +171,7 @@ the default branch). Classification:
 | remove | `stale` | Session inactive >12 hours, no unique commits |
 | keep | `dirty` | Uncommitted changes in working tree |
 | keep | `committed` | Unique commits not merged into default branch |
-| keep | `active` | Session exists, not stale, no unique commits |
+| keep | `idle`/`working` | Session exists, not stale, no unique commits |
 
 Squash merges are detected using `git merge-tree --write-tree` (requires git
 2.38+): if simulating a merge of the branch into `origin/<default>` produces a
@@ -211,7 +213,7 @@ Columns:
 |--------|-------|
 | WORKTREE | Worktree directory name (the stable identifier even if the branch is renamed). |
 | TITLE | Session title, auto-generated from the first prompt. |
-| STATUS | Highest-priority state: `attached` (TUI client connected), `working` (agent generating, no client), `idle` (session exists, no activity). Attachment is detected by scanning local `opencode attach` processes. No session shows `-`. |
+| STATUS | Highest-priority state: `attached` (TUI client connected), `working` (agent generating, no client), `idle` (session exists, no activity), `stale` (session idle >12 hours). Attachment is detected by scanning local `opencode attach` processes. No session shows `-`. |
 | ACTIVITY | How recently the session was active. `now` when the agent is streaming. When idle, shows when the last assistant message completed (e.g. `5m`, `3h`, `1d`). |
 | TOKENS | Context window size from the last assistant message in the most recent session. Formatted as `12k`, `150k`. |
 | REPO | Repo root, shortened to `<home>/.../parent/name`. `[remote]` prefix for remote worktrees. |

--- a/main.go
+++ b/main.go
@@ -352,10 +352,6 @@ func fetchRepos(entries []worktree.Entry) {
 	}
 }
 
-// staleThreshold is the duration after which a session with no unique commits
-// is considered abandoned and safe to remove.
-const staleThreshold = 12 * time.Hour
-
 // classifyForRm determines the action (remove/keep) and reason for a worktree.
 func classifyForRm(e worktree.Entry) (action, reason string) {
 	host := hostFor(e)
@@ -381,12 +377,12 @@ func classifyForRm(e worktree.Entry) (action, reason string) {
 	if merged {
 		return "remove", "merged"
 	}
-	if unique == 0 && !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > staleThreshold {
+	if unique == 0 && !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
 		return "remove", "stale"
 	}
 
-	// Not done — session active, no commits yet
-	return "keep", "active"
+	// Not done — session exists, no commits yet
+	return "keep", e.Status
 }
 
 func cmdRmBatch(remoteOnly bool, dryRun bool) {

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -42,7 +42,7 @@ func PrintTable(rows []Row) {
 	w.Flush()
 }
 
-// FormatStatus returns the highest-priority session state: attached > working > idle > -.
+// FormatStatus returns the highest-priority session state: attached > working > idle > stale > -.
 func FormatStatus(status string, attached bool) string {
 	if status == "" {
 		return "-"

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ellistarn/wt/pkg/worktree"
 )
 
+// StaleThreshold is the duration after which a session with no recent activity
+// is considered stale.
+const StaleThreshold = 12 * time.Hour
+
 // Session is the API response type from the OpenCode server.
 type Session struct {
 	ID        string `json:"id"`
@@ -111,6 +115,8 @@ func Enrich(serverURL string, entries []worktree.Entry) error {
 		if time.Since(entries[i].UpdatedAt) < 30*time.Second {
 			entries[i].Status = "working"
 			entries[i].Tokens = fetchSessionTokens(serverURL, s.ID)
+		} else if time.Since(entries[i].UpdatedAt) > StaleThreshold {
+			entries[i].Status = "stale"
 		} else {
 			entries[i].Status = "idle"
 		}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -399,9 +399,9 @@ func TestBatchRm_SessionActiveSkipped(t *testing.T) {
 	out := env.wt("rm", "--dry-run")
 	t.Log("output:\n" + out)
 
-	// Session is recent with no commits — kept as active
+	// Session is recent with no commits — kept as working
 	assertContains(t, out, "batch-active")
-	assertContains(t, out, "keep (active)")
+	assertContains(t, out, "keep (working)")
 }
 
 // --- Remote host configuration tests ---

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -199,9 +199,9 @@ func TestSSH_RemoteSessionQuery(t *testing.T) {
 		}
 	}
 
-	// wt rm should skip it (active session, default 12h stale threshold)
+	// wt rm should skip it (session exists, default 12h stale threshold)
 	out = env.wt("-r", "rm", "--dry-run")
 	t.Log("SSH rm dry-run output:\n" + out)
 	assertContains(t, out, "ssh-session")
-	assertContains(t, out, "session active")
+	assertContains(t, out, "keep (")
 }


### PR DESCRIPTION
## Summary

- Eliminate the `active` status label from `wt rm` so users only need one set of terms across `wt ls` and `wt rm`: `working`, `idle`, `stale`, `attached`.
- `Enrich()` now sets `stale` for sessions idle >12h (previously all non-working sessions were `idle`; stale was only a removal classification).
- `classifyForRm` returns the enriched session status (`idle`/`working`) instead of the separate `active` label.
- `StaleThreshold` moves to `pkg/opencode` as the single source of truth.

## Status vocabulary (before → after)

### `wt ls`
Before: `attached > working > idle > -`
After: `attached > working > idle > stale > -`

### `wt rm` keep reasons
Before: `keep (active)` — session exists, not stale
After: `keep (idle)` or `keep (working)` — reuses `wt ls` terms