### PR TITLE
Fix merge detection and targeted rm --dry-run

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,7 +258,7 @@ func cmdRm(args []string, remoteOnly bool) {
 	}
 
 	if name != "" {
-		cmdRmTargeted(name)
+		cmdRmTargeted(name, dryRun)
 	} else {
 		cmdRmBatch(remoteOnly, dryRun)
 	}
@@ -362,7 +362,10 @@ func classifyForRm(e worktree.Entry) (action, reason string) {
 		keepReasons = append(keepReasons, "dirty")
 	}
 	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
-	merged := git.IsMerged(host, e.Repo, e.Name)
+	var merged bool
+	if unique > 0 {
+		merged = git.IsMerged(host, e.Repo, e.Name)
+	}
 	if unique > 0 && !merged {
 		keepReasons = append(keepReasons, "committed")
 	}
@@ -469,18 +472,22 @@ func cmdRmBatch(remoteOnly bool, dryRun bool) {
 	}
 }
 
-func cmdRmTargeted(name string) {
+func cmdRmTargeted(name string, dryRun bool) {
 	entry, ok := findWorktree(name)
 	if !ok {
 		die("worktree %q not found", name)
 	}
 	host := hostFor(entry)
-	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
-		die("%v", err)
+	status := "remove"
+	if !dryRun {
+		if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
+			die("%v", err)
+		}
+		status = "removed"
 	}
 	display.PrintTable([]display.Row{{
 		Entry:  entry,
-		Status: "removed",
+		Status: status,
 	}})
 }
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -108,9 +108,8 @@ func UniqueCommitCount(host, repo, branch string) int {
 	return n
 }
 
-// IsMerged returns true if the branch was pushed to origin and its changes are
-// incorporated into origin/<default>. A branch that was never pushed cannot be
-// "merged" — it's either fresh or was only worked on locally.
+// IsMerged returns true if the branch's changes are incorporated into
+// origin/<default> (regular merge, fast-forward, or squash merge).
 //
 // Detection is two-phase:
 //  1. Ancestry check — catches regular merges and fast-forward merges.
@@ -118,11 +117,11 @@ func UniqueCommitCount(host, repo, branch string) int {
 //     branch into origin/<default> and checks whether the result tree is
 //     identical to origin/<default>'s tree (i.e., the branch adds nothing new).
 //     Requires git 2.38+.
+//
+// Callers should only invoke this when the branch has unique commits
+// (UniqueCommitCount > 0). A branch with no divergence trivially matches
+// the target tree and would produce a false positive.
 func IsMerged(host, repo, branch string) bool {
-	// A branch that was never pushed can't be "merged."
-	if _, err := runGit(host, repo, "rev-parse", "--verify", "refs/remotes/origin/"+branch); err != nil {
-		return false
-	}
 	def := DefaultBranch(host, repo)
 	target := "origin/" + def
 
@@ -132,9 +131,6 @@ func IsMerged(host, repo, branch string) bool {
 	}
 
 	// Slow path: merge-tree simulation (squash merge).
-	// Simulate merging the branch into the target. If the resulting tree
-	// equals the target's current tree, the branch's diff is a no-op —
-	// its changes are already in the target regardless of commit history.
 	mergeTree, err := runGit(host, repo, "merge-tree", "--write-tree", target, branch)
 	if err != nil {
 		return false // conflict or git too old — not merged
@@ -152,25 +148,7 @@ func IsClean(host, dir string) bool {
 	return err == nil && out == ""
 }
 
-// IsPushed returns true if the branch has a remote tracking ref on origin and
-// the local branch is not ahead of it.
-func IsPushed(host, repo, branch string) bool {
-	// Check that the remote tracking ref exists
-	if _, err := runGit(host, repo, "rev-parse", "--verify", "refs/remotes/origin/"+branch); err != nil {
-		return false
-	}
-	// Check local is not ahead
-	out, err := runGit(host, repo, "rev-list", "--count", "origin/"+branch+".."+branch)
-	if err != nil {
-		return false
-	}
-	n, _ := strconv.Atoi(out)
-	return n == 0
-}
-
-// Fetch updates remote tracking refs for a repo. Does not prune — keeping
-// refs for deleted remote branches is needed for merge detection (IsMerged
-// checks whether origin/<branch> exists as a signal the branch was pushed).
+// Fetch updates remote tracking refs for a repo.
 func Fetch(host, repo string) {
 	runGit(host, repo, "fetch", "origin")
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -387,6 +387,36 @@ func TestBatchRm_DryRun(t *testing.T) {
 	}
 }
 
+// TestBatchRm_RegressionPrunedTrackingRef verifies that squash merge detection
+// works even when the remote tracking ref (refs/remotes/origin/<branch>) has
+// been pruned. Previously IsMerged gated on the tracking ref existing, so
+// fetch.prune=true would cause merged branches to be classified as "committed".
+func TestBatchRm_RegressionPrunedTrackingRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	// Create a branch, push, squash-merge, then prune the tracking ref
+	wt := env.addWorktree("pruned-ref")
+	env.commitFile(wt, "h.txt", "pruned", "pruned feature")
+	env.push("pruned-ref")
+	env.createSession(wt)
+	env.squashMergeToMain("pruned-ref")
+	gitCmd(t, env.repo, "checkout", "main")
+
+	// Simulate fetch.prune=true deleting the tracking ref
+	gitCmd(t, env.repo, "update-ref", "-d", "refs/remotes/origin/pruned-ref")
+
+	out := env.wt("rm", "--dry-run")
+	t.Log("output:\n" + out)
+
+	if !strings.Contains(out, "pruned-ref") || !strings.Contains(out, "remove (merged)") {
+		t.Error("squash-merged worktree with pruned tracking ref should be classified as remove (merged)")
+	}
+}
+
 func TestBatchRm_SessionActiveSkipped(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -157,11 +157,11 @@ func TestSSH_BatchRm_DryRun(t *testing.T) {
 	out := env.wt("-r", "rm", "--dry-run")
 	t.Log("SSH dry-run output:\n" + out)
 
-	assertContains(t, out, "Would remove")
+	assertContains(t, out, "remove")
 	assertContains(t, out, "ssh-clean")
 	assertContains(t, out, "ssh-merged")
 
-	assertContains(t, out, "Skipped")
+	assertContains(t, out, "keep")
 	assertContains(t, out, "ssh-dirty")
 	assertContains(t, out, "ssh-unpushed")
 }


### PR DESCRIPTION
## Summary

- **Merge detection**: removed `refs/remotes/origin/<branch>` prerequisite from `IsMerged` — the design never called for it, and `fetch.prune=true` (common git config) prunes these refs after PR merge, causing `IsMerged` to bail before the merge-tree simulation that would detect squash merges. Guard with `unique > 0` to prevent false positives on fresh branches.
- **Targeted dry-run**: `cmdRm` parsed `--dry-run` but never passed it to `cmdRmTargeted`, so `wt rm --dry-run <name>` silently removed the worktree.
- **Cleanup**: removed dead `IsPushed` function, stale no-prune comment on `Fetch`.
- **Regression test**: `TestBatchRm_RegressionPrunedTrackingRef` — squash-merges, deletes tracking ref, verifies `remove (merged)`.