### PR TITLE
Unify ls and rm into single status model

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -152,33 +152,23 @@ All attach operations follow the same steps:
 If no session exists for the worktree, `opencode attach` is run without
 `--session`. OpenCode creates a new session on first prompt.
 
-### `wt rm [name] [--dry-run]`
+### `wt rm [name]`
 
 Remove worktrees.
 
 **Targeted** (`wt rm <name>`): removes the worktree unconditionally.
 Force-deletes the worktree directory and branch. The user already knows the
-state from `wt ls` or `wt rm --dry-run`.
+state from `wt ls`.
 
-**Batch** (`wt rm`): removes worktrees that are safe to clean up. A worktree is
-safe when there is no at-risk git state (clean working tree, no commits not on
-the default branch). Classification:
-
-| Action | Label | Meaning |
-|--------|-------|---------|
-| remove | `empty` | No session was ever created |
-| remove | `merged` | Changes incorporated into `origin/<default>` (regular, fast-forward, or squash merge) |
-| remove | `stale` | Session inactive >12 hours, no unique commits |
-| keep | `dirty` | Uncommitted changes in working tree |
-| keep | `committed` | Unique commits not merged into default branch |
-| keep | `idle`/`working` | Session exists, not stale, no unique commits |
+**Batch** (`wt rm`): removes worktrees whose status is `merged`, `stale`, or
+`empty`. These are the worktrees with no at-risk state — either the work
+landed, the session went dormant with no commits, or no session was ever
+created. All other statuses are kept. `wt ls` is the preview.
 
 Squash merges are detected using `git merge-tree --write-tree` (requires git
 2.38+): if simulating a merge of the branch into `origin/<default>` produces a
 tree identical to the target's current tree, the branch's changes are already
 incorporated.
-
-- `--dry-run`: preview classification without removing.
 
 All read paths (ls, rm) fetch from origin to ensure remote-tracking refs are
 current. Removal deletes the worktree
@@ -186,9 +176,9 @@ directory and the branch. Session history in the database is not touched.
 
 ### `wt ls`
 
-List all worktrees and their session status. Local worktrees (all repos under
-`$HOME`) and remote worktrees (all repos on the dev desktop) are discovered
-concurrently and merged into a single table sorted by most recent activity.
+List all worktrees with their status. Local worktrees (all repos under `$HOME`)
+and remote worktrees (all repos on the dev desktop) are discovered concurrently
+and merged into a single table sorted by most recent activity.
 
 Session metadata is fetched from the OpenCode server API, not from the database
 directly. For each server (local and remote):
@@ -199,12 +189,16 @@ directly. For each server (local and remote):
    message's total token count (context window size) and derives working/idle
    from whether that message has completed.
 
+Git state is determined per worktree by checking the working tree and branch
+against `origin/<default>`.
+
 ```
-WORKTREE            TITLE                           STATUS    ACTIVITY  TOKENS  REPO                              AGE
-0423T1430-12847     Fix auth handler validation      attached  now       150k    [remote] /home/user/.../acme/api   3h
-0423T1600-4419      Refactor config parser           idle      5m        42k     /Users/user/.../acme/api           1d
-0423T1700-8812      Migrate database schema          working   now       12k     [remote] /home/user/.../acme/api   2h
-0421T1100-5531      -                                -         -         -       [remote] /home/user/.../acme/web   2d
+WORKTREE            TITLE                           STATUS       ACTIVITY  TOKENS  REPO                              AGE
+0423T1430-12847     Fix auth handler validation      attached     now       150k    [remote] /home/user/.../acme/api   3h
+0423T1600-4419      Refactor config parser           committed    5m        42k     /Users/user/.../acme/api           1d
+0423T1700-8812      Migrate database schema          working      now       12k     [remote] /home/user/.../acme/api   2h
+0423T0900-2210      Add retry logic                  merged *     1h        80k     /Users/user/.../acme/api           2d
+0421T1100-5531      -                                empty *      -         -       [remote] /home/user/.../acme/web   2d
 ```
 
 Columns:
@@ -212,16 +206,32 @@ Columns:
 | Column | Value |
 |--------|-------|
 | WORKTREE | Worktree directory name (the stable identifier even if the branch is renamed). |
-| TITLE | Session title, auto-generated from the first prompt. |
-| STATUS | Highest-priority state: `attached` (TUI client connected), `working` (agent generating, no client), `idle` (session exists, no activity), `stale` (session idle >12 hours). Attachment is detected by scanning local `opencode attach` processes. No session shows `-`. |
-| ACTIVITY | How recently the session was active. `now` when the agent is streaming. When idle, shows when the last assistant message completed (e.g. `5m`, `3h`, `1d`). |
-| TOKENS | Context window size from the last assistant message in the most recent session. Formatted as `12k`, `150k`. |
+| TITLE | Session title, auto-generated from the first prompt. `-` if no session. |
+| STATUS | Single highest-priority state from the table below. |
+| ACTIVITY | How recently the session was active. `now` when the agent is streaming. When idle, shows when the last assistant message completed (e.g. `5m`, `3h`, `1d`). `-` if no session. |
+| TOKENS | Context window size from the last assistant message in the most recent session. Formatted as `12k`, `150k`. `-` if no session. |
 | REPO | Repo root, shortened to `<home>/.../parent/name`. `[remote]` prefix for remote worktrees. |
 | AGE | When the worktree was created. |
 
-`-` in any column means the value is unavailable. A worktree with no session
-shows `-` for STATUS, ACTIVITY, TOKENS, and TITLE. Attaching to such a worktree
-creates a session on first prompt; subsequent listings show its status and title.
+Status values, in priority order (highest wins). Statuses marked `*` are
+removed by `wt rm`.
+
+| Status | Meaning |
+|--------|---------|
+| `attached` | TUI client connected |
+| `working` | Agent generating, no client |
+| `dirty` | Uncommitted changes in working tree |
+| `merged *` | Changes incorporated into `origin/<default>` |
+| `committed` | Unique commits not in `origin/<default>` |
+| `idle` | Session exists, no unique commits, recent |
+| `stale *` | Session inactive >12 hours, no unique commits |
+| `empty *` | No session was ever created |
+
+Session states (`attached`, `working`) take priority — the worktree is in active
+use. Git states (`dirty`, `merged`, `committed`) take priority next — they
+describe the safety of the work. Session lifecycle states (`idle`, `stale`,
+`empty`) apply when the working tree is clean and the branch has no unique
+commits. Attachment is detected by scanning local `opencode attach` processes.
 
 ## Reconnection
 
@@ -295,3 +305,7 @@ long-lived tunnel amortizes the cost across all `wt` commands.
 **Remote TUI over SSH** — Running the TUI on the remote host and forwarding the
 terminal adds latency to every keystroke and breaks the local-client model where
 `opencode attach` runs on the laptop.
+
+**`wt rm --dry-run`** — `wt ls` already shows the unified status that determines
+what `wt rm` will remove. A separate preview command duplicates information the
+user can read from `ls`.

--- a/main.go
+++ b/main.go
@@ -221,46 +221,34 @@ func findWorktree(name string) (worktree.Entry, bool) {
 // cmdLs handles: wt ls
 func cmdLs(remoteOnly bool) {
 	all, enrichErr := discoverAll(remoteOnly)
+	if enrichErr != nil {
+		die("%v", enrichErr)
+	}
 	worktree.Sort(all)
 
 	if len(all) == 0 {
 		fmt.Println("No worktrees found.")
 		return
 	}
-	if enrichErr != nil {
-		die("%v", enrichErr)
-	}
 	rows := make([]display.Row, len(all))
 	for i, e := range all {
 		rows[i] = display.Row{
 			Entry:  e,
-			Status: display.FormatStatus(e.Status, e.Attached),
+			Status: classifyStatus(e),
 		}
 	}
 	display.PrintTable(rows)
 }
 
-// cmdRm handles: wt rm [name] [--dry-run]
+// cmdRm handles: wt rm [name]
 func cmdRm(args []string, remoteOnly bool) {
-	var name string
-	dryRun := false
-
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "--dry-run":
-			dryRun = true
-		default:
-			if name != "" {
-				die("unexpected argument: %s", args[i])
-			}
-			name = args[i]
-		}
+	if len(args) > 1 {
+		die("unexpected argument: %s", args[1])
 	}
-
-	if name != "" {
-		cmdRmTargeted(name, dryRun)
+	if len(args) == 1 {
+		cmdRmTargeted(args[0])
 	} else {
-		cmdRmBatch(remoteOnly, dryRun)
+		cmdRmBatch(remoteOnly)
 	}
 }
 
@@ -352,43 +340,46 @@ func fetchRepos(entries []worktree.Entry) {
 	}
 }
 
-// classifyForRm determines the action (remove/keep) and reason for a worktree.
-func classifyForRm(e worktree.Entry) (action, reason string) {
-	host := hostFor(e)
+// classifyStatus returns the single highest-priority status for a worktree.
+// Priority: attached > working > dirty > merged > committed > idle > stale > empty.
+func classifyStatus(e worktree.Entry) string {
+	// Session states — active use takes priority
+	if e.Attached {
+		return "attached"
+	}
+	if e.Status == "working" {
+		return "working"
+	}
 
-	// Data safety — keep worktrees with at-risk changes
-	var keepReasons []string
+	// Git states — data safety
+	host := hostFor(e)
 	if !git.IsClean(host, e.Dir) {
-		keepReasons = append(keepReasons, "dirty")
+		return "dirty"
 	}
 	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
-	var merged bool
 	if unique > 0 {
-		merged = git.IsMerged(host, e.Repo, e.Name)
-	}
-	if unique > 0 && !merged {
-		keepReasons = append(keepReasons, "committed")
-	}
-	if len(keepReasons) > 0 {
-		return "keep", strings.Join(keepReasons, ", ")
+		if git.IsMerged(host, e.Repo, e.Name) {
+			return "merged"
+		}
+		return "committed"
 	}
 
-	// Safe to remove — determine why
+	// Session lifecycle — no unique commits, clean tree
 	if e.SessionID == "" {
-		return "remove", "empty"
+		return "empty"
 	}
-	if merged {
-		return "remove", "merged"
+	if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
+		return "stale"
 	}
-	if unique == 0 && !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
-		return "remove", "stale"
-	}
-
-	// Not done — session exists, no commits yet
-	return "keep", e.Status
+	return "idle"
 }
 
-func cmdRmBatch(remoteOnly bool, dryRun bool) {
+// isRemovable returns true if a status indicates the worktree is safe to remove.
+func isRemovable(status string) bool {
+	return status == "merged" || status == "stale" || status == "empty"
+}
+
+func cmdRmBatch(remoteOnly bool) {
 	all, enrichErr := discoverAll(remoteOnly)
 	if enrichErr != nil {
 		die("cannot determine session status: %v", enrichErr)
@@ -399,45 +390,37 @@ func cmdRmBatch(remoteOnly bool, dryRun bool) {
 		return
 	}
 
-	type classified struct {
+	type result struct {
 		entry  worktree.Entry
-		action string
-		reason string
+		status string
 		errMsg string
 	}
-	var results []classified
+	var results []result
 	var removeCount int
 
 	for _, e := range all {
-		action, reason := classifyForRm(e)
-
-		// Actually remove if not dry-run
+		status := classifyStatus(e)
 		var errMsg string
-		if action == "remove" && !dryRun {
+
+		if isRemovable(status) {
 			host := hostFor(e)
 			if err := git.WorktreeRemove(host, e.Repo, e.Name); err != nil {
-				action = "keep"
-				reason = "error"
 				errMsg = strings.ReplaceAll(strings.TrimSpace(err.Error()), "\n", " ")
 			} else {
-				action = "removed"
+				status = "removed"
+				removeCount++
 			}
 		}
 
-		if action == "remove" || action == "removed" {
-			removeCount++
-		}
-		results = append(results, classified{e, action, reason, errMsg})
+		results = append(results, result{e, status, errMsg})
 	}
 
-	// Sort: removes first, then keeps; by activity (newest first) within each group
-	isRemove := func(action string) bool { return action == "remove" || action == "removed" }
+	// Sort: removed first, then by activity (newest first)
 	sort.SliceStable(results, func(i, j int) bool {
-		ri, rj := isRemove(results[i].action), isRemove(results[j].action)
+		ri, rj := results[i].status == "removed", results[j].status == "removed"
 		if ri != rj {
 			return ri
 		}
-		// Within same group, sort by activity (newest first)
 		ti, tj := results[i].entry.UpdatedAt, results[j].entry.UpdatedAt
 		if !ti.IsZero() && !tj.IsZero() {
 			return ti.After(tj)
@@ -445,17 +428,14 @@ func cmdRmBatch(remoteOnly bool, dryRun bool) {
 		if !ti.IsZero() {
 			return true
 		}
-		if !tj.IsZero() {
-			return false
-		}
-		return false
+		return !tj.IsZero() && false
 	})
 
 	rows := make([]display.Row, len(results))
 	for i, r := range results {
 		rows[i] = display.Row{
 			Entry:  r.entry,
-			Status: fmt.Sprintf("%s (%s)", r.action, r.reason),
+			Status: r.status,
 		}
 	}
 	display.PrintTable(rows)
@@ -472,22 +452,18 @@ func cmdRmBatch(remoteOnly bool, dryRun bool) {
 	}
 }
 
-func cmdRmTargeted(name string, dryRun bool) {
+func cmdRmTargeted(name string) {
 	entry, ok := findWorktree(name)
 	if !ok {
 		die("worktree %q not found", name)
 	}
 	host := hostFor(entry)
-	status := "remove"
-	if !dryRun {
-		if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
-			die("%v", err)
-		}
-		status = "removed"
+	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
+		die("%v", err)
 	}
 	display.PrintTable([]display.Row{{
 		Entry:  entry,
-		Status: status,
+		Status: "removed",
 	}})
 }
 
@@ -501,9 +477,18 @@ Usage:
   wt -r <path>              Create a new remote worktree and attach
   wt ls                     List all worktrees (local and remote)
   wt -r ls                  List remote worktrees only
-  wt rm                     Remove all safe-to-remove worktrees
-  wt rm --dry-run           Preview what would be removed
+  wt rm                     Remove worktrees marked * in wt ls
   wt rm <name>              Remove a specific worktree
+
+Status:
+  attached    TUI client connected
+  working     Agent generating
+  dirty       Uncommitted changes in working tree
+  merged *    Changes incorporated into default branch
+  committed   Unique commits not yet in default branch
+  idle        Session exists, no unique commits
+  stale *     Session inactive >12 hours, no unique commits
+  empty *     No session was ever created
 
 Flags:
   -r, --remote              Operate on the remote dev desktop
@@ -526,7 +511,7 @@ func printExitRow(serverURL string, entry worktree.Entry) {
 	entry = entries[0]
 	display.PrintTable([]display.Row{{
 		Entry:  entry,
-		Status: display.FormatStatus(entry.Status, entry.Attached),
+		Status: classifyStatus(entry),
 	}})
 }
 

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -11,13 +11,20 @@ import (
 )
 
 // Row is a single row in the worktree table. Callers provide the Entry and a
-// pre-formatted Status string (e.g. "working", "remove (stale)").
+// pre-formatted Status string (e.g. "working", "merged", "removed").
 type Row struct {
 	Entry  worktree.Entry
 	Status string
 }
 
-// PrintTable prints rows as an aligned table.
+// removableStatuses are cleaned up by `wt rm` and marked with * in listings.
+var removableStatuses = map[string]bool{
+	"merged": true,
+	"stale":  true,
+	"empty":  true,
+}
+
+// PrintTable prints rows as an aligned table. Removable statuses get a * suffix.
 func PrintTable(rows []Row) {
 	if len(rows) == 0 {
 		return
@@ -28,6 +35,10 @@ func PrintTable(rows []Row) {
 	now := time.Now()
 	for _, r := range rows {
 		e := r.Entry
+		status := r.Status
+		if removableStatuses[status] {
+			status += " *"
+		}
 		activity := formatActivity(e.UpdatedAt, now)
 		tokens := formatTokens(e.Tokens)
 		title := e.Title
@@ -36,21 +47,10 @@ func PrintTable(rows []Row) {
 		}
 		repo := formatRepo(e.Repo, e.Remote)
 		age := formatDuration(e.CreatedAt, now)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, r.Status, title, repo, tokens, activity, age)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, repo, tokens, activity, age)
 	}
 
 	w.Flush()
-}
-
-// FormatStatus returns the highest-priority session state: attached > working > idle > stale > -.
-func FormatStatus(status string, attached bool) string {
-	if status == "" {
-		return "-"
-	}
-	if attached {
-		return "attached"
-	}
-	return status
 }
 
 // formatActivity returns how long ago the session was active, or "now" if streaming.

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -10,26 +10,6 @@ import (
 	"github.com/ellistarn/wt/pkg/worktree"
 )
 
-func TestFormatStatus(t *testing.T) {
-	tests := []struct {
-		status   string
-		attached bool
-		want     string
-	}{
-		{"", false, "-"},
-		{"idle", false, "idle"},
-		{"working", false, "working"},
-		{"idle", true, "attached"},
-		{"working", true, "attached"},
-	}
-	for _, tt := range tests {
-		got := FormatStatus(tt.status, tt.attached)
-		if got != tt.want {
-			t.Errorf("FormatStatus(%q, %v) = %q, want %q", tt.status, tt.attached, got, tt.want)
-		}
-	}
-}
-
 func TestFormatTokens(t *testing.T) {
 	tests := []struct {
 		tokens int
@@ -121,7 +101,7 @@ func TestPrintTable(t *testing.T) {
 				Repo:      "/home/user/src/github.com/acme/project",
 				CreatedAt: now.Add(-1 * time.Hour),
 			},
-			Status: "-",
+			Status: "empty",
 		},
 	}
 
@@ -169,8 +149,11 @@ func TestPrintTable(t *testing.T) {
 		t.Errorf("expected title in row 1: %s", lines[1])
 	}
 
-	// Second row: no session, dashes everywhere.
+	// Second row: empty status with * marker.
 	if !strings.Contains(lines[2], "0424T1035-627") {
 		t.Errorf("expected worktree name in row 2: %s", lines[2])
+	}
+	if !strings.Contains(lines[2], "empty *") {
+		t.Errorf("expected 'empty *' in row 2: %s", lines[2])
 	}
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -150,6 +150,23 @@ func (e *testEnv) createSession(dir string) {
 	e.sessionMu.Unlock()
 }
 
+func (e *testEnv) createIdleSession(dir string) {
+	e.t.Helper()
+	now := time.Now()
+	idle := now.Add(-1 * time.Hour)
+	e.sessionMu.Lock()
+	e.sessions = append(e.sessions, mockSession{
+		ID:        fmt.Sprintf("ses_test_%d", len(e.sessions)),
+		Directory: dir,
+		Title:     "Test instruction compliance",
+		Time: struct {
+			Created int64 `json:"created"`
+			Updated int64 `json:"updated"`
+		}{Created: idle.UnixMilli(), Updated: idle.UnixMilli()},
+	})
+	e.sessionMu.Unlock()
+}
+
 func (e *testEnv) startMockServer() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/global/health", func(w http.ResponseWriter, r *http.Request) {
@@ -160,12 +177,6 @@ func (e *testEnv) startMockServer() {
 		sessions := make([]mockSession, len(e.sessions))
 		copy(sessions, e.sessions)
 		e.sessionMu.Unlock()
-
-		// Update timestamps to keep sessions "fresh" (within 30s = working)
-		now := time.Now().UnixMilli()
-		for i := range sessions {
-			sessions[i].Time.Updated = now
-		}
 
 		dir := r.URL.Query().Get("directory")
 		if dir != "" {
@@ -324,74 +335,68 @@ func TestTargetedRm_PushedUnmerged(t *testing.T) {
 	}
 }
 
-// --- Batch tests (dry-run only to avoid touching real worktrees) ---
+// --- Batch tests ---
 
-func TestBatchRm_DryRun(t *testing.T) {
+func TestLs_UnifiedStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
 	}
 	t.Parallel()
 	env := newTestEnv(t)
 
-	// Would remove: clean, no session
+	// empty *: clean, no session
 	env.addWorktree("batch-clean")
 
-	// Would remove: merged
+	// empty *: regular merge (commits become ancestors of main → unique=0, no session)
 	wt2 := env.addWorktree("batch-merged")
 	env.commitFile(wt2, "f.txt", "done", "feature")
 	env.push("batch-merged")
 	env.mergeToMain("batch-merged")
 	gitCmd(t, env.repo, "checkout", "main")
 
-	// Would remove: squash-merged (with session, so classified as "merged" not "empty")
+	// merged *: squash-merged (unique>0 but merge-tree detects content in main)
+	// Uses idle session so "working" doesn't take priority over "merged".
 	wt5 := env.addWorktree("batch-squashed")
 	env.commitFile(wt5, "g.txt", "squashed", "squash feature")
 	env.push("batch-squashed")
-	env.createSession(wt5)
+	env.createIdleSession(wt5)
 	env.squashMergeToMain("batch-squashed")
 	gitCmd(t, env.repo, "checkout", "main")
 
-	// Skipped: dirty
+	// dirty: uncommitted changes
 	wt3 := env.addWorktree("batch-dirty")
 	os.WriteFile(filepath.Join(wt3, "f.txt"), []byte("x"), 0644)
 
-	// Skipped: unpushed
+	// committed: unpushed commits
 	wt4 := env.addWorktree("batch-unpushed")
 	env.commitFile(wt4, "a.txt", "a", "local")
 
-	out := env.wt("rm", "--dry-run")
+	out := env.wt("ls")
 	t.Log("output:\n" + out)
 
 	assertContains(t, out, "batch-clean")
 	assertContains(t, out, "batch-merged")
 	assertContains(t, out, "batch-squashed")
-	assertContains(t, out, "remove (")
+	assertContains(t, out, "empty *")
 
-	// Squash-merged branch has a session and unique commits, but merge-tree
+	// Squash-merged branch has an idle session and unique commits, but merge-tree
 	// detection recognizes its changes are in main — classified as "merged".
-	// Without squash detection it would be "keep (committed)".
-	if !strings.Contains(out, "batch-squashed") || !strings.Contains(out, "remove (merged)") {
-		t.Error("squash-merged worktree should be classified as remove (merged)")
+	// Without squash detection it would be "committed".
+	if !strings.Contains(out, "batch-squashed") || !strings.Contains(out, "merged *") {
+		t.Error("squash-merged worktree should be classified as merged *")
 	}
 
 	assertContains(t, out, "batch-dirty")
-	assertContains(t, out, "keep (dirty")
+	assertContains(t, out, "dirty")
 	assertContains(t, out, "batch-unpushed")
-	assertContains(t, out, "keep (committed")
-
-	// Nothing actually removed
-	for _, name := range []string{"batch-clean", "batch-merged", "batch-squashed", "batch-dirty", "batch-unpushed"} {
-		if !env.worktreeExists(name) {
-			t.Errorf("worktree %q removed during dry-run", name)
-		}
-	}
+	assertContains(t, out, "committed")
 }
 
-// TestBatchRm_RegressionPrunedTrackingRef verifies that squash merge detection
+// TestLs_RegressionPrunedTrackingRef verifies that squash merge detection
 // works even when the remote tracking ref (refs/remotes/origin/<branch>) has
 // been pruned. Previously IsMerged gated on the tracking ref existing, so
 // fetch.prune=true would cause merged branches to be classified as "committed".
-func TestBatchRm_RegressionPrunedTrackingRef(t *testing.T) {
+func TestLs_RegressionPrunedTrackingRef(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
 	}
@@ -402,22 +407,22 @@ func TestBatchRm_RegressionPrunedTrackingRef(t *testing.T) {
 	wt := env.addWorktree("pruned-ref")
 	env.commitFile(wt, "h.txt", "pruned", "pruned feature")
 	env.push("pruned-ref")
-	env.createSession(wt)
+	env.createIdleSession(wt)
 	env.squashMergeToMain("pruned-ref")
 	gitCmd(t, env.repo, "checkout", "main")
 
 	// Simulate fetch.prune=true deleting the tracking ref
 	gitCmd(t, env.repo, "update-ref", "-d", "refs/remotes/origin/pruned-ref")
 
-	out := env.wt("rm", "--dry-run")
+	out := env.wt("ls")
 	t.Log("output:\n" + out)
 
-	if !strings.Contains(out, "pruned-ref") || !strings.Contains(out, "remove (merged)") {
-		t.Error("squash-merged worktree with pruned tracking ref should be classified as remove (merged)")
+	if !strings.Contains(out, "pruned-ref") || !strings.Contains(out, "merged *") {
+		t.Error("squash-merged worktree with pruned tracking ref should be classified as merged *")
 	}
 }
 
-func TestBatchRm_SessionActiveSkipped(t *testing.T) {
+func TestLs_SessionActiveStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
 	}
@@ -426,12 +431,40 @@ func TestBatchRm_SessionActiveSkipped(t *testing.T) {
 	wt := env.addWorktree("batch-active")
 	env.createSession(wt)
 
-	out := env.wt("rm", "--dry-run")
+	out := env.wt("ls")
 	t.Log("output:\n" + out)
 
-	// Session is recent with no commits — kept as working
+	// Session is recent with no commits — shown as working
 	assertContains(t, out, "batch-active")
-	assertContains(t, out, "keep (working)")
+	assertContains(t, out, "working")
+}
+
+func TestBatchRm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	// empty * → removed
+	env.addWorktree("rm-empty")
+
+	// dirty → kept
+	wt2 := env.addWorktree("rm-dirty")
+	os.WriteFile(filepath.Join(wt2, "f.txt"), []byte("x"), 0644)
+
+	out := env.wt("rm")
+	t.Log("output:\n" + out)
+
+	assertContains(t, out, "rm-empty")
+	assertContains(t, out, "removed")
+
+	if !env.worktreeExists("rm-dirty") {
+		t.Error("dirty worktree should not be removed")
+	}
+	if env.worktreeExists("rm-empty") {
+		t.Error("empty worktree should have been removed")
+	}
 }
 
 // --- Remote host configuration tests ---

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -131,39 +131,42 @@ func sshRunErr(host, script string) (string, error) {
 
 // --- SSH path tests ---
 
-func TestSSH_BatchRm_DryRun(t *testing.T) {
+func TestSSH_Ls_UnifiedStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping SSH e2e test in short mode")
 	}
 	env := newSSHTestEnv(t)
 
-	// Clean, no session → should be removed
+	// Clean, no session → empty *
 	env.addWorktree("ssh-clean")
 
-	// Dirty → should be skipped
+	// Dirty → dirty
 	wt2 := env.addWorktree("ssh-dirty")
 	sshRun(t, env.host, fmt.Sprintf("echo dirty > %s/dirty.txt", wt2))
 
-	// Unpushed → should be skipped
+	// Unpushed → committed
 	wt3 := env.addWorktree("ssh-unpushed")
 	env.commitFile(wt3, "a.txt", "a", "unpushed")
 
-	// Pushed + merged → should be removed
+	// Pushed + merged (regular, not squash) with no session → empty *
+	// After a regular merge, the branch's commits are ancestors of main,
+	// so UniqueCommitCount is 0. With no session, status is "empty".
 	wt4 := env.addWorktree("ssh-merged")
 	env.commitFile(wt4, "f.txt", "f", "feature")
 	env.push("ssh-merged")
 	env.mergeToMain("ssh-merged")
 
-	out := env.wt("-r", "rm", "--dry-run")
-	t.Log("SSH dry-run output:\n" + out)
+	out := env.wt("-r", "ls")
+	t.Log("SSH ls output:\n" + out)
 
-	assertContains(t, out, "remove")
 	assertContains(t, out, "ssh-clean")
+	assertContains(t, out, "empty *")
 	assertContains(t, out, "ssh-merged")
 
-	assertContains(t, out, "keep")
 	assertContains(t, out, "ssh-dirty")
+	assertContains(t, out, "dirty")
 	assertContains(t, out, "ssh-unpushed")
+	assertContains(t, out, "committed")
 }
 
 func TestSSH_RemoteSessionQuery(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace separate session-status (ls) and git-classification (rm --dry-run) with a single priority-ordered STATUS: `attached > working > dirty > merged > committed > idle > stale > empty`
- Both `ls` and `rm` use `classifyStatus`. Removable statuses (`merged`, `stale`, `empty`) show a `*` suffix in `ls` so users know what `wt rm` will clean up
- `--dry-run` removed — `ls` is the preview
- Fix `IsMerged` failing when `fetch.prune=true` by removing the `refs/remotes/origin/<branch>` prerequisite the design never called for
- Regression test for pruned tracking ref scenario