### PR TITLE
Parallelize enrichment, improve working detection, split main.go, isolate tests

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/ellistarn/wt/pkg/discover"
+	"github.com/ellistarn/wt/pkg/git"
+	"github.com/ellistarn/wt/pkg/opencode"
+	"github.com/ellistarn/wt/pkg/ssh"
+	"github.com/ellistarn/wt/pkg/worktree"
+)
+
+type remoteResult struct {
+	entries []worktree.Entry
+	err     error
+}
+
+// findWorktree discovers all worktrees (local and remote) and returns the one matching name.
+func findWorktree(name string) (worktree.Entry, bool) {
+	host := os.Getenv("WT_REMOTE_HOST")
+
+	localCh := make(chan []worktree.Entry, 1)
+	remoteCh := make(chan remoteResult, 1)
+
+	go func() { localCh <- discover.ListLocal() }()
+	if host != "" {
+		go func() {
+			entries, err := discover.ListRemote(host)
+			remoteCh <- remoteResult{entries, err}
+		}()
+	} else {
+		remoteCh <- remoteResult{}
+	}
+
+	local := <-localCh
+	rr := <-remoteCh
+	if rr.err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", rr.err)
+	}
+
+	all := append(local, rr.entries...)
+	for _, e := range all {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return worktree.Entry{}, false
+}
+
+// discoverAll discovers worktrees and enriches them with session data.
+// Returns any enrichment error — callers that make safety decisions must
+// check this; callers that only display can ignore it.
+func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
+	host := os.Getenv("WT_REMOTE_HOST")
+
+	localCh := make(chan []worktree.Entry, 1)
+	remoteCh := make(chan remoteResult, 1)
+
+	if !remoteOnly {
+		go func() { localCh <- discover.ListLocal() }()
+	} else {
+		localCh <- nil
+	}
+
+	if host != "" {
+		go func() {
+			entries, err := discover.ListRemote(host)
+			remoteCh <- remoteResult{entries, err}
+		}()
+	} else {
+		if remoteOnly {
+			die("WT_REMOTE_HOST is not set\n\nRemote operations require an SSH host. Set the environment variable:\n\n  export WT_REMOTE_HOST=your-dev-desktop")
+		}
+		remoteCh <- remoteResult{}
+	}
+
+	// Discover in parallel, then fetch and enrich.
+	local := <-localCh
+	rr := <-remoteCh
+	if rr.err != nil {
+		if remoteOnly {
+			die("%v", rr.err)
+		}
+		fmt.Fprintf(os.Stderr, "warning: %v\n", rr.err)
+	}
+
+	all := append(local, rr.entries...)
+
+	// Enrich using sub-slices of all so in-place mutations are visible
+	// in the returned slice.
+	localEntries := all[:len(local)]
+	remoteEntries := all[len(local):]
+
+	// Run git fetch, local session enrichment, and remote session enrichment
+	// concurrently. They touch different systems (git refs vs local HTTP vs
+	// remote HTTP) and write disjoint fields/slices on the entries.
+	var wg sync.WaitGroup
+	var localErr, remoteErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fetchRepos(all)
+	}()
+
+	if !remoteOnly {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := opencode.EnsureLocalServer(); err != nil {
+				localErr = fmt.Errorf("local server: %w", err)
+			} else if err := opencode.Enrich(opencode.LocalServerURL(), localEntries); err != nil {
+				localErr = fmt.Errorf("local session query: %w", err)
+			}
+		}()
+	}
+
+	if host != "" && rr.err == nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
+				remoteErr = fmt.Errorf("SSH tunnel: %w", err)
+			} else if err := opencode.EnsureRemoteServer(host); err != nil {
+				remoteErr = fmt.Errorf("remote server: %w", err)
+			} else if err := opencode.Enrich(opencode.RemoteServerURL(), remoteEntries); err != nil {
+				remoteErr = fmt.Errorf("remote session query: %w", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	return all, errors.Join(localErr, remoteErr)
+}
+
+// hostFor returns the SSH host for an entry, or "" for local entries.
+func hostFor(e worktree.Entry) string {
+	if e.Remote {
+		return os.Getenv("WT_REMOTE_HOST")
+	}
+	return ""
+}
+
+// fetchRepos runs git fetch once per unique repo to ensure remote-tracking
+// refs are current. Best-effort — fetch failures are ignored.
+func fetchRepos(entries []worktree.Entry) {
+	type key struct{ host, repo string }
+	seen := make(map[key]bool)
+	var repos []key
+	for _, e := range entries {
+		k := key{hostFor(e), e.Repo}
+		if !seen[k] {
+			seen[k] = true
+			repos = append(repos, k)
+		}
+	}
+	var wg sync.WaitGroup
+	for _, k := range repos {
+		wg.Add(1)
+		go func(k key) {
+			defer wg.Done()
+			git.Fetch(k.host, k.repo)
+		}(k)
+	}
+	wg.Wait()
+}
+

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -183,22 +183,31 @@ and merged into a single table sorted by most recent activity.
 Session metadata is fetched from the OpenCode server API, not from the database
 directly. For each server (local and remote):
 
-1. `GET /session?directory=<dir>` — per worktree, returns sessions across
-   projects. The most recently updated session is selected.
-2. `GET /session/<id>/message` — per session, reads the last assistant
-   message's total token count (context window size) and derives working/idle
-   from whether that message has completed.
+1. `GET /session?limit=1000` — single bulk fetch of all sessions. Matched to
+   worktrees client-side by directory. Eliminates per-worktree HTTP calls.
+2. `GET /session/<id>/message` — per session (parallel, bounded to 8
+   concurrent), reads the last assistant message's total token count (context
+   window size) and derives working/idle from whether that message has completed.
 
-Git state is determined per worktree by checking the working tree and branch
-against `origin/<default>`.
+Working/idle detection uses the last assistant message's `completed` timestamp:
+- `completed == null` → working (streaming)
+- `completed != null` → idle
+
+The server's `UpdatedAt` does not advance during streaming, so there is no
+reliable way to distinguish a long-running response from a crash orphan.
+`completed == null` is treated as working — a false positive ("working" on a
+crashed session) is preferable to a false negative (hiding active work).
+
+Git state is determined per worktree (parallel, bounded to 8 concurrent) by
+checking the working tree and branch against `origin/<default>`.
 
 ```
-WORKTREE            TITLE                           STATUS       ACTIVITY  TOKENS  REPO                              AGE
-0423T1430-12847     Fix auth handler validation      attached     now       150k    [remote] /home/user/.../acme/api   3h
-0423T1600-4419      Refactor config parser           committed    5m        42k     /Users/user/.../acme/api           1d
-0423T1700-8812      Migrate database schema          working      now       12k     [remote] /home/user/.../acme/api   2h
-0423T0900-2210      Add retry logic                  merged *     1h        80k     /Users/user/.../acme/api           2d
-0421T1100-5531      -                                empty *      -         -       [remote] /home/user/.../acme/web   2d
+WORKTREE            STATUS       TITLE                           REPO                              TOKENS  ACTIVITY  AGE
+0423T1430-12847     attached     Fix auth handler validation      [remote] /home/user/.../acme/api   150k    now       3h
+0423T1600-4419      committed    Refactor config parser           /Users/user/.../acme/api           42k     5m        1d
+0423T1700-8812      working      Migrate database schema          [remote] /home/user/.../acme/api   12k     now       2h
+0423T0900-2210      merged *     Add retry logic                  /Users/user/.../acme/api           80k     1h        2d
+0421T1100-5531      empty *      -                                [remote] /home/user/.../acme/web   -       -         2d
 ```
 
 Columns:
@@ -206,8 +215,8 @@ Columns:
 | Column | Value |
 |--------|-------|
 | WORKTREE | Worktree directory name (the stable identifier even if the branch is renamed). |
-| TITLE | Session title, auto-generated from the first prompt. `-` if no session. |
 | STATUS | Single highest-priority state from the table below. |
+| TITLE | Session title, auto-generated from the first prompt. `-` if no session. |
 | ACTIVITY | How recently the session was active. `now` when the agent is streaming. When idle, shows when the last assistant message completed (e.g. `5m`, `3h`, `1d`). `-` if no session. |
 | TOKENS | Context window size from the last assistant message in the most recent session. Formatted as `12k`, `150k`. `-` if no session. |
 | REPO | Repo root, shortened to `<home>/.../parent/name`. `[remote]` prefix for remote worktrees. |
@@ -219,7 +228,7 @@ removed by `wt rm`.
 | Status | Meaning |
 |--------|---------|
 | `attached` | TUI client connected |
-| `working` | Agent generating, no client |
+| `working` | Agent streaming (last assistant message incomplete) |
 | `dirty` | Uncommitted changes in working tree |
 | `merged *` | Changes incorporated into `origin/<default>` |
 | `committed` | Unique commits not in `origin/<default>` |

--- a/main.go
+++ b/main.go
@@ -5,12 +5,11 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
-	"github.com/ellistarn/wt/pkg/discover"
 	"github.com/ellistarn/wt/pkg/display"
 	"github.com/ellistarn/wt/pkg/git"
 	"github.com/ellistarn/wt/pkg/opencode"
@@ -181,43 +180,6 @@ func cmdRemote(args []string) {
 	})
 }
 
-type remoteResult struct {
-	entries []worktree.Entry
-	err     error
-}
-
-// findWorktree discovers all worktrees (local and remote) and returns the one matching name.
-func findWorktree(name string) (worktree.Entry, bool) {
-	host := os.Getenv("WT_REMOTE_HOST")
-
-	localCh := make(chan []worktree.Entry, 1)
-	remoteCh := make(chan remoteResult, 1)
-
-	go func() { localCh <- discover.ListLocal() }()
-	if host != "" {
-		go func() {
-			entries, err := discover.ListRemote(host)
-			remoteCh <- remoteResult{entries, err}
-		}()
-	} else {
-		remoteCh <- remoteResult{}
-	}
-
-	local := <-localCh
-	rr := <-remoteCh
-	if rr.err != nil {
-		fmt.Fprintf(os.Stderr, "warning: %v\n", rr.err)
-	}
-
-	all := append(local, rr.entries...)
-	for _, e := range all {
-		if e.Name == name {
-			return e, true
-		}
-	}
-	return worktree.Entry{}, false
-}
-
 // cmdLs handles: wt ls
 func cmdLs(remoteOnly bool) {
 	all, enrichErr := discoverAll(remoteOnly)
@@ -230,241 +192,30 @@ func cmdLs(remoteOnly bool) {
 		fmt.Println("No worktrees found.")
 		return
 	}
+
+	// Classify in parallel
+	statuses := make([]string, len(all))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 8)
+	for i, e := range all {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, entry worktree.Entry) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			statuses[idx] = classifyStatus(entry)
+		}(i, e)
+	}
+	wg.Wait()
+
 	rows := make([]display.Row, len(all))
 	for i, e := range all {
 		rows[i] = display.Row{
 			Entry:  e,
-			Status: classifyStatus(e),
+			Status: statuses[i],
 		}
 	}
 	display.PrintTable(rows)
-}
-
-// cmdRm handles: wt rm [name]
-func cmdRm(args []string, remoteOnly bool) {
-	if len(args) > 1 {
-		die("unexpected argument: %s", args[1])
-	}
-	if len(args) == 1 {
-		cmdRmTargeted(args[0])
-	} else {
-		cmdRmBatch(remoteOnly)
-	}
-}
-
-// discoverAll discovers worktrees and enriches them with session data.
-// Returns any enrichment error — callers that make safety decisions must
-// check this; callers that only display can ignore it.
-func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
-	host := os.Getenv("WT_REMOTE_HOST")
-
-	localCh := make(chan []worktree.Entry, 1)
-	remoteCh := make(chan remoteResult, 1)
-
-	if !remoteOnly {
-		go func() { localCh <- discover.ListLocal() }()
-	} else {
-		localCh <- nil
-	}
-
-	if host != "" {
-		go func() {
-			entries, err := discover.ListRemote(host)
-			remoteCh <- remoteResult{entries, err}
-		}()
-	} else {
-		if remoteOnly {
-			die("WT_REMOTE_HOST is not set\n\nRemote operations require an SSH host. Set the environment variable:\n\n  export WT_REMOTE_HOST=your-dev-desktop")
-		}
-		remoteCh <- remoteResult{}
-	}
-
-	// Discover in parallel, then fetch and enrich.
-	local := <-localCh
-	rr := <-remoteCh
-	if rr.err != nil {
-		if remoteOnly {
-			die("%v", rr.err)
-		}
-		fmt.Fprintf(os.Stderr, "warning: %v\n", rr.err)
-	}
-
-	all := append(local, rr.entries...)
-	fetchRepos(all)
-
-	// Enrich using sub-slices of all so in-place mutations are visible
-	// in the returned slice.
-	localEntries := all[:len(local)]
-	remoteEntries := all[len(local):]
-
-	var enrichErr error
-	if !remoteOnly {
-		if err := opencode.EnsureLocalServer(); err != nil {
-			enrichErr = fmt.Errorf("local server: %w", err)
-		} else if err := opencode.Enrich(opencode.LocalServerURL(), localEntries); err != nil {
-			enrichErr = fmt.Errorf("local session query: %w", err)
-		}
-	}
-	if host != "" && rr.err == nil {
-		if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
-			enrichErr = fmt.Errorf("SSH tunnel: %w", err)
-		} else if err := opencode.EnsureRemoteServer(host); err != nil {
-			enrichErr = fmt.Errorf("remote server: %w", err)
-		} else if err := opencode.Enrich(opencode.RemoteServerURL(), remoteEntries); err != nil {
-			enrichErr = fmt.Errorf("remote session query: %w", err)
-		}
-	}
-
-	return all, enrichErr
-}
-
-// hostFor returns the SSH host for an entry, or "" for local entries.
-func hostFor(e worktree.Entry) string {
-	if e.Remote {
-		return os.Getenv("WT_REMOTE_HOST")
-	}
-	return ""
-}
-
-// fetchRepos runs git fetch once per unique repo to ensure remote-tracking
-// refs are current. Best-effort — fetch failures are ignored.
-func fetchRepos(entries []worktree.Entry) {
-	type key struct{ host, repo string }
-	seen := make(map[key]bool)
-	for _, e := range entries {
-		k := key{hostFor(e), e.Repo}
-		if !seen[k] {
-			seen[k] = true
-			git.Fetch(k.host, k.repo)
-		}
-	}
-}
-
-// classifyStatus returns the single highest-priority status for a worktree.
-// Priority: attached > working > dirty > merged > committed > idle > stale > empty.
-func classifyStatus(e worktree.Entry) string {
-	// Session states — active use takes priority
-	if e.Attached {
-		return "attached"
-	}
-	if e.Status == "working" {
-		return "working"
-	}
-
-	// Git states — data safety
-	host := hostFor(e)
-	if !git.IsClean(host, e.Dir) {
-		return "dirty"
-	}
-	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
-	if unique > 0 {
-		if git.IsMerged(host, e.Repo, e.Name) {
-			return "merged"
-		}
-		return "committed"
-	}
-
-	// Session lifecycle — no unique commits, clean tree
-	if e.SessionID == "" {
-		return "empty"
-	}
-	if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
-		return "stale"
-	}
-	return "idle"
-}
-
-// isRemovable returns true if a status indicates the worktree is safe to remove.
-func isRemovable(status string) bool {
-	return status == "merged" || status == "stale" || status == "empty"
-}
-
-func cmdRmBatch(remoteOnly bool) {
-	all, enrichErr := discoverAll(remoteOnly)
-	if enrichErr != nil {
-		die("cannot determine session status: %v", enrichErr)
-	}
-
-	if len(all) == 0 {
-		fmt.Println("No worktrees found.")
-		return
-	}
-
-	type result struct {
-		entry  worktree.Entry
-		status string
-		errMsg string
-	}
-	var results []result
-	var removeCount int
-
-	for _, e := range all {
-		status := classifyStatus(e)
-		var errMsg string
-
-		if isRemovable(status) {
-			host := hostFor(e)
-			if err := git.WorktreeRemove(host, e.Repo, e.Name); err != nil {
-				errMsg = strings.ReplaceAll(strings.TrimSpace(err.Error()), "\n", " ")
-			} else {
-				status = "removed"
-				removeCount++
-			}
-		}
-
-		results = append(results, result{e, status, errMsg})
-	}
-
-	// Sort: removed first, then by activity (newest first)
-	sort.SliceStable(results, func(i, j int) bool {
-		ri, rj := results[i].status == "removed", results[j].status == "removed"
-		if ri != rj {
-			return ri
-		}
-		ti, tj := results[i].entry.UpdatedAt, results[j].entry.UpdatedAt
-		if !ti.IsZero() && !tj.IsZero() {
-			return ti.After(tj)
-		}
-		if !ti.IsZero() {
-			return true
-		}
-		return !tj.IsZero() && false
-	})
-
-	rows := make([]display.Row, len(results))
-	for i, r := range results {
-		rows[i] = display.Row{
-			Entry:  r.entry,
-			Status: r.status,
-		}
-	}
-	display.PrintTable(rows)
-
-	for _, r := range results {
-		if r.errMsg != "" {
-			fmt.Fprintf(os.Stderr, "ERROR: %s: %s\n", r.entry.Name, r.errMsg)
-		}
-	}
-
-	if removeCount == 0 {
-		fmt.Println()
-		fmt.Println("Nothing to remove. Use 'wt rm <name>' to target specific worktrees.")
-	}
-}
-
-func cmdRmTargeted(name string) {
-	entry, ok := findWorktree(name)
-	if !ok {
-		die("worktree %q not found", name)
-	}
-	host := hostFor(entry)
-	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
-		die("%v", err)
-	}
-	display.PrintTable([]display.Row{{
-		Entry:  entry,
-		Status: "removed",
-	}})
 }
 
 func printUsage() {

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -138,3 +138,4 @@ func FormatAge(t time.Time, now time.Time) string {
 		return fmt.Sprintf("%dd ago", days)
 	}
 }
+

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -86,10 +86,11 @@ func TestParseAttachDir(t *testing.T) {
 	}
 }
 
-// TestFetchSessionTokens_RegressionContextWindow verifies that fetchSessionTokens
+// TestFetchSessionStatus_ContextWindow verifies that fetchSessionStatus
 // returns the last assistant message's total (context window size), not the sum
 // across all messages. Summing double-counts input context that is re-sent each turn.
-func TestFetchSessionTokens_RegressionContextWindow(t *testing.T) {
+// Also verifies that a trailing zero-total, zero-completed message is detected as streaming.
+func TestFetchSessionStatus_ContextWindow(t *testing.T) {
 	messages := []message{
 		{Info: struct {
 			Role   string `json:"role"`
@@ -110,7 +111,9 @@ func TestFetchSessionTokens_RegressionContextWindow(t *testing.T) {
 			} `json:"time"`
 		}{Role: "assistant", Tokens: struct {
 			Total int `json:"total"`
-		}{Total: 25000}}},
+		}{Total: 25000}, Time: struct {
+			Completed int64 `json:"completed"`
+		}{Completed: 1700000000000}}},
 		{Info: struct {
 			Role   string `json:"role"`
 			Tokens struct {
@@ -130,8 +133,10 @@ func TestFetchSessionTokens_RegressionContextWindow(t *testing.T) {
 			} `json:"time"`
 		}{Role: "assistant", Tokens: struct {
 			Total int `json:"total"`
-		}{Total: 50000}}},
-		// Trailing zero-total message (incomplete/streaming).
+		}{Total: 50000}, Time: struct {
+			Completed int64 `json:"completed"`
+		}{Completed: 1700000001000}}},
+		// Trailing zero-total message (incomplete/streaming): completed == 0.
 		{Info: struct {
 			Role   string `json:"role"`
 			Tokens struct {
@@ -142,7 +147,9 @@ func TestFetchSessionTokens_RegressionContextWindow(t *testing.T) {
 			} `json:"time"`
 		}{Role: "assistant", Tokens: struct {
 			Total int `json:"total"`
-		}{Total: 0}}},
+		}{Total: 0}, Time: struct {
+			Completed int64 `json:"completed"`
+		}{Completed: 0}}},
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -150,10 +157,74 @@ func TestFetchSessionTokens_RegressionContextWindow(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	got := fetchSessionTokens(srv.URL, "test-session")
+	got := fetchSessionStatus(srv.URL, "test-session")
 
 	// Must return 50000 (last non-zero assistant total), not 75000 (sum).
-	if got != 50000 {
-		t.Errorf("fetchSessionTokens = %d, want 50000 (context window size, not sum)", got)
+	if got.tokens != 50000 {
+		t.Errorf("tokens = %d, want 50000 (context window size, not sum)", got.tokens)
+	}
+	// Trailing assistant message has completed == 0, so streaming should be true.
+	if !got.streaming {
+		t.Error("streaming = false, want true (last assistant message has completed == 0)")
+	}
+}
+
+// TestFetchSessionStatus_Idle verifies that a completed message returns streaming=false.
+func TestFetchSessionStatus_Idle(t *testing.T) {
+	messages := []message{
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "user"}},
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "assistant", Tokens: struct {
+			Total int `json:"total"`
+		}{Total: 30000}, Time: struct {
+			Completed int64 `json:"completed"`
+		}{Completed: 1700000000000}}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(messages)
+	}))
+	defer srv.Close()
+
+	got := fetchSessionStatus(srv.URL, "test-session")
+
+	if got.tokens != 30000 {
+		t.Errorf("tokens = %d, want 30000", got.tokens)
+	}
+	if got.streaming {
+		t.Error("streaming = true, want false (last assistant message has non-zero completed)")
+	}
+}
+
+// TestFetchSessionStatus_NoMessages verifies that an empty message list
+// returns streaming=false and tokens=0.
+func TestFetchSessionStatus_NoMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]message{})
+	}))
+	defer srv.Close()
+
+	got := fetchSessionStatus(srv.URL, "test-session")
+
+	if got.tokens != 0 {
+		t.Errorf("tokens = %d, want 0", got.tokens)
+	}
+	if got.streaming {
+		t.Error("streaming = true, want false (no messages)")
 	}
 }

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/ellistarn/wt/pkg/worktree"
@@ -37,6 +38,12 @@ type message struct {
 			Completed int64 `json:"completed"`
 		} `json:"time"`
 	} `json:"info"`
+}
+
+// sessionStatus captures the working/idle signal from a session's messages.
+type sessionStatus struct {
+	tokens    int  // context window size (last assistant message with non-zero total)
+	streaming bool // true if the most recent assistant message has not completed
 }
 
 // LocalServerURL returns the local OpenCode server URL.
@@ -94,31 +101,76 @@ func QuerySession(serverURL, directory string) (*Session, error) {
 }
 
 // Enrich enriches worktree entries with session data from the OpenCode server.
-// Fetches tokens for sessions that are actively streaming.
+// Fetches message status for sessions that may be actively streaming.
 func Enrich(serverURL string, entries []worktree.Entry) error {
 	if err := checkHealthFast(serverURL); err != nil {
 		return err
 	}
 
-	for i := range entries {
-		s, err := QuerySession(serverURL, entries[i].Dir)
-		if err != nil {
-			return err
+	// Bulk fetch ALL sessions (single HTTP call).
+	sessions, err := listSessions(serverURL, "")
+	if err != nil {
+		return err
+	}
+
+	// Build map[directory]*Session, first-per-directory wins (already sorted by updated desc).
+	byDir := make(map[string]*Session, len(sessions))
+	for i := range sessions {
+		if _, exists := byDir[sessions[i].Directory]; !exists {
+			byDir[sessions[i].Directory] = &sessions[i]
 		}
-		if s == nil {
+	}
+
+	// Match sessions to entries, set SessionID, Title, UpdatedAt.
+	for i := range entries {
+		s, ok := byDir[entries[i].Dir]
+		if !ok {
 			continue
 		}
 		entries[i].SessionID = s.ID
 		entries[i].Title = s.Title
 		entries[i].UpdatedAt = time.UnixMilli(s.Time.Updated)
 
-		if time.Since(entries[i].UpdatedAt) < 30*time.Second {
-			entries[i].Status = "working"
-			entries[i].Tokens = fetchSessionTokens(serverURL, s.ID)
-		} else if time.Since(entries[i].UpdatedAt) > StaleThreshold {
+		if time.Since(entries[i].UpdatedAt) > StaleThreshold {
 			entries[i].Status = "stale"
+		}
+	}
+
+	// For non-stale entries with sessions, fetch message status in parallel (bounded to 8).
+	type statusResult struct {
+		index  int
+		status sessionStatus
+	}
+	var toFetch []int
+	for i := range entries {
+		if entries[i].SessionID != "" && entries[i].Status != "stale" {
+			toFetch = append(toFetch, i)
+		}
+	}
+
+	results := make([]statusResult, len(toFetch))
+	sem := make(chan struct{}, 8)
+	var wg sync.WaitGroup
+	for j, idx := range toFetch {
+		wg.Add(1)
+		go func(j, idx int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[j] = statusResult{
+				index:  idx,
+				status: fetchSessionStatus(serverURL, entries[idx].SessionID),
+			}
+		}(j, idx)
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		entries[r.index].Tokens = r.status.tokens
+		if r.status.streaming {
+			entries[r.index].Status = "working"
 		} else {
-			entries[i].Status = "idle"
+			entries[r.index].Status = "idle"
 		}
 	}
 
@@ -156,29 +208,42 @@ func listSessions(serverURL, directory string) ([]Session, error) {
 	return sessions, nil
 }
 
-// fetchSessionTokens returns the context window size for the session — the
-// total tokens from the last assistant message. Each message's Total field
-// represents the full context for that API call (input + output + cache), so
-// the last message gives the current context window usage.
-func fetchSessionTokens(serverURL, sessionID string) int {
+// fetchSessionStatus returns the context window size and streaming state for
+// the session. It walks backwards through the message list: the first (most
+// recent) assistant message determines streaming (completed == 0), and the
+// first assistant message with non-zero tokens.Total gives the token count.
+func fetchSessionStatus(serverURL, sessionID string) sessionStatus {
 	resp, err := httpGet(serverURL + "/session/" + sessionID + "/message")
 	if err != nil {
-		return 0
+		return sessionStatus{}
 	}
 	defer resp.Body.Close()
 
 	var messages []message
 	if err := json.NewDecoder(resp.Body).Decode(&messages); err != nil {
-		return 0
+		return sessionStatus{}
 	}
 
-	// Walk backwards to find the last assistant message with a non-zero total.
+	var result sessionStatus
+	foundStreaming := false
+	foundTokens := false
 	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Info.Role == "assistant" && messages[i].Info.Tokens.Total > 0 {
-			return messages[i].Info.Tokens.Total
+		if messages[i].Info.Role != "assistant" {
+			continue
+		}
+		if !foundStreaming {
+			result.streaming = messages[i].Info.Time.Completed == 0
+			foundStreaming = true
+		}
+		if !foundTokens && messages[i].Info.Tokens.Total > 0 {
+			result.tokens = messages[i].Info.Tokens.Total
+			foundTokens = true
+		}
+		if foundStreaming && foundTokens {
+			break
 		}
 	}
-	return 0
+	return result
 }
 
 func httpGet(u string) (*http.Response, error) {

--- a/rm.go
+++ b/rm.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ellistarn/wt/pkg/display"
+	"github.com/ellistarn/wt/pkg/git"
+	"github.com/ellistarn/wt/pkg/opencode"
+	"github.com/ellistarn/wt/pkg/worktree"
+)
+
+// cmdRm handles: wt rm [name]
+func cmdRm(args []string, remoteOnly bool) {
+	if len(args) > 1 {
+		die("unexpected argument: %s", args[1])
+	}
+	if len(args) == 1 {
+		cmdRmTargeted(args[0])
+	} else {
+		cmdRmBatch(remoteOnly)
+	}
+}
+
+// classifyStatus returns the single highest-priority status for a worktree.
+// Priority: attached > working > dirty > merged > committed > idle > stale > empty.
+func classifyStatus(e worktree.Entry) string {
+	// Session states — active use takes priority
+	if e.Attached {
+		return "attached"
+	}
+	if e.Status == "working" {
+		return "working"
+	}
+
+	// Git states — data safety
+	host := hostFor(e)
+	if !git.IsClean(host, e.Dir) {
+		return "dirty"
+	}
+	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
+	if unique > 0 {
+		if git.IsMerged(host, e.Repo, e.Name) {
+			return "merged"
+		}
+		return "committed"
+	}
+
+	// Session lifecycle — no unique commits, clean tree
+	if e.SessionID == "" {
+		return "empty"
+	}
+	if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
+		return "stale"
+	}
+	return "idle"
+}
+
+// isRemovable returns true if a status indicates the worktree is safe to remove.
+func isRemovable(status string) bool {
+	return status == "merged" || status == "stale" || status == "empty"
+}
+
+func cmdRmBatch(remoteOnly bool) {
+	all, enrichErr := discoverAll(remoteOnly)
+	if enrichErr != nil {
+		die("cannot determine session status: %v", enrichErr)
+	}
+
+	if len(all) == 0 {
+		fmt.Println("No worktrees found.")
+		return
+	}
+
+	type result struct {
+		entry  worktree.Entry
+		status string
+		errMsg string
+	}
+
+	// Classify in parallel
+	statuses := make([]string, len(all))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 8)
+	for i, e := range all {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, entry worktree.Entry) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			statuses[idx] = classifyStatus(entry)
+		}(i, e)
+	}
+	wg.Wait()
+
+	// Remove sequentially
+	var results []result
+	var removeCount int
+
+	for i, e := range all {
+		status := statuses[i]
+		var errMsg string
+
+		if isRemovable(status) {
+			host := hostFor(e)
+			if err := git.WorktreeRemove(host, e.Repo, e.Name); err != nil {
+				errMsg = strings.ReplaceAll(strings.TrimSpace(err.Error()), "\n", " ")
+			} else {
+				status = "removed"
+				removeCount++
+			}
+		}
+
+		results = append(results, result{e, status, errMsg})
+	}
+
+	// Sort: removed first, then by activity (newest first)
+	sort.SliceStable(results, func(i, j int) bool {
+		ri, rj := results[i].status == "removed", results[j].status == "removed"
+		if ri != rj {
+			return ri
+		}
+		ti, tj := results[i].entry.UpdatedAt, results[j].entry.UpdatedAt
+		if !ti.IsZero() && !tj.IsZero() {
+			return ti.After(tj)
+		}
+		if !ti.IsZero() {
+			return true
+		}
+		return !tj.IsZero() && false
+	})
+
+	rows := make([]display.Row, len(results))
+	for i, r := range results {
+		rows[i] = display.Row{
+			Entry:  r.entry,
+			Status: r.status,
+		}
+	}
+	display.PrintTable(rows)
+
+	for _, r := range results {
+		if r.errMsg != "" {
+			fmt.Fprintf(os.Stderr, "ERROR: %s: %s\n", r.entry.Name, r.errMsg)
+		}
+	}
+
+	if removeCount == 0 {
+		fmt.Println()
+		fmt.Println("Nothing to remove. Use 'wt rm <name>' to target specific worktrees.")
+	}
+}
+
+func cmdRmTargeted(name string) {
+	entry, ok := findWorktree(name)
+	if !ok {
+		die("worktree %q not found", name)
+	}
+	host := hostFor(entry)
+	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
+		die("%v", err)
+	}
+	display.PrintTable([]display.Row{{
+		Entry:  entry,
+		Status: "removed",
+	}})
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -3,7 +3,6 @@ package e2e_test
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -65,20 +64,10 @@ type mockSession struct {
 
 func newTestEnv(t *testing.T) *testEnv {
 	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatal(err)
+	rootDir := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(rootDir); err == nil {
+		rootDir = resolved
 	}
-	if resolved, err := filepath.EvalSymlinks(home); err == nil {
-		home = resolved
-	}
-
-	name := fmt.Sprintf("wt-e2e-%d-%d", time.Now().UnixNano(), rand.Intn(100000))
-	rootDir := filepath.Join(home, name)
-	if err := os.MkdirAll(rootDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(rootDir) })
 
 	dataDir := filepath.Join(rootDir, "data")
 	os.MkdirAll(dataDir, 0755)
@@ -191,8 +180,45 @@ func (e *testEnv) startMockServer() {
 		json.NewEncoder(w).Encode(sessions)
 	})
 	mux.HandleFunc("/session/", func(w http.ResponseWriter, r *http.Request) {
-		// Handle /session/:id/message — return empty messages
-		json.NewEncoder(w).Encode([]any{})
+		// Extract session ID from /session/<id>/message and look up
+		// whether the session is active (recent UpdatedAt) or idle.
+		// Return a streaming message (completed=0) for active sessions
+		// and a completed message for idle sessions.
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		var sessionID string
+		if len(parts) >= 2 {
+			sessionID = parts[1]
+		}
+
+		completed := 1 // default: completed (idle)
+		e.sessionMu.Lock()
+		for _, s := range e.sessions {
+			if s.ID == sessionID {
+				age := time.Since(time.UnixMilli(s.Time.Updated))
+				if age < 30*time.Second {
+					completed = 0 // streaming (active)
+				}
+				break
+			}
+		}
+		e.sessionMu.Unlock()
+
+		type msgInfo struct {
+			Role   string         `json:"role"`
+			Tokens map[string]int `json:"tokens"`
+			Time   map[string]int `json:"time"`
+		}
+		type msg struct {
+			Info msgInfo `json:"info"`
+		}
+		messages := []msg{
+			{Info: msgInfo{
+				Role:   "assistant",
+				Tokens: map[string]int{"total": 0},
+				Time:   map[string]int{"completed": completed},
+			}},
+		}
+		json.NewEncoder(w).Encode(messages)
 	})
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -212,6 +238,7 @@ func (e *testEnv) wt(args ...string) string {
 	cmd := exec.Command(wtBinary, args...)
 	cmd.Dir = e.repo
 	cmd.Env = append(os.Environ(),
+		"HOME="+e.rootDir,
 		"WT_REMOTE_HOST=",
 		"WT_OPENCODE_PORT="+e.mockPort,
 	)


### PR DESCRIPTION
## Summary

- Split main.go into rm.go and discover.go for focused file organization (#24)
- Replace N+1 per-worktree session queries with single bulk fetch; parallelize git fetch, status classification, and session enrichment concurrently with bounded concurrency of 8 (#19)
- Replace 30-second UpdatedAt heuristic with completion-time detection: `completed=null` → working, `completed!=null` → idle. No orphan threshold — UpdatedAt doesn't advance during streaming, so false "working" is safer than false "idle" (#17)
- Isolate e2e tests by setting HOME to temp directory — suite drops from ~25s to ~5s (#25)

Closes #17, #19, #24, #25