### PR TITLE
Fix session enrichment matching for remote worktrees with symlinked paths

### DIFF
--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/ellistarn/wt/pkg/worktree"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -226,5 +229,72 @@ func TestFetchSessionStatus_NoMessages(t *testing.T) {
 	}
 	if got.streaming {
 		t.Error("streaming = true, want false (no messages)")
+	}
+}
+
+func TestWorktreeName(t *testing.T) {
+	tests := []struct {
+		dir  string
+		want string
+	}{
+		{"/home/user/repo/.worktrees/0425T1457-57407", "0425T1457-57407"},
+		{"/local/home/user/repo/.worktrees/0425T1457-57407", "0425T1457-57407"},
+		{"/home/user/repo", ""},
+		{"", ""},
+		{"/home/user/.worktrees/", ""},
+		{"/home/user/.worktrees/name/subdir", ""},
+	}
+	for _, tt := range tests {
+		if got := worktreeName(tt.dir); got != tt.want {
+			t.Errorf("worktreeName(%q) = %q, want %q", tt.dir, got, tt.want)
+		}
+	}
+}
+
+// TestEnrich_RegressionSymlinkPaths verifies that session enrichment matches
+// by worktree name, not full path. This broke when remote hosts had symlinked
+// home directories (e.g. /local/home/user vs /home/user) causing the session
+// directory to differ from the discovered worktree directory.
+func TestEnrich_RegressionSymlinkPaths(t *testing.T) {
+	sessions := []Session{
+		{
+			ID:        "sess-1",
+			Directory: "/local/home/user/repo/.worktrees/0425T1457-57407",
+			Title:     "fix auth bug",
+			Time: struct {
+				Created int64 `json:"created"`
+				Updated int64 `json:"updated"`
+			}{Updated: time.Now().UnixMilli()},
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/global/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(sessions)
+	})
+	mux.HandleFunc("/session/sess-1/message", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]message{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	entries := []worktree.Entry{
+		{
+			Name: "0425T1457-57407",
+			Dir:  "/home/user/repo/.worktrees/0425T1457-57407", // different path, same worktree name
+		},
+	}
+
+	if err := Enrich(srv.URL, entries); err != nil {
+		t.Fatalf("Enrich: %v", err)
+	}
+	if entries[0].SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want %q", entries[0].SessionID, "sess-1")
+	}
+	if entries[0].Title != "fix auth bug" {
+		t.Errorf("Title = %q, want %q", entries[0].Title, "fix auth bug")
 	}
 }

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -113,17 +114,22 @@ func Enrich(serverURL string, entries []worktree.Entry) error {
 		return err
 	}
 
-	// Build map[directory]*Session, first-per-directory wins (already sorted by updated desc).
-	byDir := make(map[string]*Session, len(sessions))
+	// Match sessions to entries by worktree name — the unique timestamp-based
+	// ID in the /.worktrees/<name> path. Matching by name instead of full path
+	// avoids mismatches from symlink differences across hosts (e.g.
+	// /local/home/user/... vs /home/user/...).
+	// First-per-name wins (sessions are already sorted by updated desc).
+	byName := make(map[string]*Session, len(sessions))
 	for i := range sessions {
-		if _, exists := byDir[sessions[i].Directory]; !exists {
-			byDir[sessions[i].Directory] = &sessions[i]
+		if name := worktreeName(sessions[i].Directory); name != "" {
+			if _, exists := byName[name]; !exists {
+				byName[name] = &sessions[i]
+			}
 		}
 	}
 
-	// Match sessions to entries, set SessionID, Title, UpdatedAt.
 	for i := range entries {
-		s, ok := byDir[entries[i].Dir]
+		s, ok := byName[entries[i].Name]
 		if !ok {
 			continue
 		}
@@ -244,6 +250,19 @@ func fetchSessionStatus(serverURL, sessionID string) sessionStatus {
 		}
 	}
 	return result
+}
+
+// worktreeName extracts the worktree name from a path containing /.worktrees/<name>.
+// Returns "" if the path doesn't match the pattern.
+func worktreeName(dir string) string {
+	const marker = "/.worktrees/"
+	if i := strings.LastIndex(dir, marker); i >= 0 {
+		name := dir[i+len(marker):]
+		if name != "" && !strings.Contains(name, "/") {
+			return name
+		}
+	}
+	return ""
 }
 
 func httpGet(u string) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- **Bug:** `Enrich()` matched sessions to worktrees by exact directory path string equality. On remote hosts with symlinked home directories (e.g. `/local/home/user` vs `/home/user`), the discovered worktree path and the OpenCode session directory never matched, leaving title, status, and tokens empty in `wt ls`.
- **Fix:** Match by worktree name (the unique timestamp-based ID in the `/.worktrees/<name>` path) instead of full directory path. Worktree names are stable across path representations.
- **Test:** Added `TestEnrich_RegressionSymlinkPaths` reproducing the exact failure, plus `TestWorktreeName` covering the helper.