### PR TITLE
Overlap fetch with classification, cache DefaultBranch, multiplex SSH

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -51,9 +51,11 @@ func findWorktree(name string) (worktree.Entry, bool) {
 }
 
 // discoverAll discovers worktrees and enriches them with session data.
+// Git fetch runs concurrently with enrichment; per-repo done channels are
+// returned so callers can gate classification on each repo's fetch completing.
 // Returns any enrichment error — callers that make safety decisions must
 // check this; callers that only display can ignore it.
-func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
+func discoverAll(remoteOnly bool) ([]worktree.Entry, fetchResult, error) {
 	host := os.Getenv("WT_REMOTE_HOST")
 
 	localCh := make(chan []worktree.Entry, 1)
@@ -94,17 +96,13 @@ func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
 	localEntries := all[:len(local)]
 	remoteEntries := all[len(local):]
 
-	// Run git fetch, local session enrichment, and remote session enrichment
-	// concurrently. They touch different systems (git refs vs local HTTP vs
-	// remote HTTP) and write disjoint fields/slices on the entries.
+	// Run git fetch and session enrichment concurrently. Fetch is non-blocking —
+	// per-repo done channels are returned for callers to wait on per-entry,
+	// overlapping fetch with classification instead of serializing them.
 	var wg sync.WaitGroup
 	var localErr, remoteErr error
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		fetchRepos(all)
-	}()
+	fetched := startFetchRepos(all)
 
 	if !remoteOnly {
 		wg.Add(1)
@@ -134,7 +132,7 @@ func discoverAll(remoteOnly bool) ([]worktree.Entry, error) {
 
 	wg.Wait()
 
-	return all, errors.Join(localErr, remoteErr)
+	return all, fetched, errors.Join(localErr, remoteErr)
 }
 
 // hostFor returns the SSH host for an entry, or "" for local entries.
@@ -145,27 +143,37 @@ func hostFor(e worktree.Entry) string {
 	return ""
 }
 
-// fetchRepos runs git fetch once per unique repo to ensure remote-tracking
-// refs are current. Best-effort — fetch failures are ignored.
-func fetchRepos(entries []worktree.Entry) {
-	type key struct{ host, repo string }
-	seen := make(map[key]bool)
-	var repos []key
+// fetchResult holds per-repo done channels from a non-blocking fetch.
+// Wait blocks until the given entry's repo has been fetched.
+type fetchResult map[repoKey]<-chan struct{}
+
+func (f fetchResult) Wait(e worktree.Entry) {
+	if ch, ok := f[repoKey{hostFor(e), e.Repo}]; ok {
+		<-ch
+	}
+}
+
+type repoKey struct{ host, repo string }
+
+// startFetchRepos kicks off git fetch for each unique repo and returns
+// immediately. Each repo gets its own goroutine; the returned channels
+// close when each repo's fetch completes.
+func startFetchRepos(entries []worktree.Entry) fetchResult {
+	seen := make(map[repoKey]bool)
+	result := make(fetchResult)
 	for _, e := range entries {
-		k := key{hostFor(e), e.Repo}
-		if !seen[k] {
-			seen[k] = true
-			repos = append(repos, k)
+		k := repoKey{hostFor(e), e.Repo}
+		if seen[k] {
+			continue
 		}
-	}
-	var wg sync.WaitGroup
-	for _, k := range repos {
-		wg.Add(1)
-		go func(k key) {
-			defer wg.Done()
+		seen[k] = true
+		ch := make(chan struct{})
+		result[k] = ch
+		go func(k repoKey, ch chan struct{}) {
 			git.Fetch(k.host, k.repo)
-		}(k)
+			close(ch)
+		}(k, ch)
 	}
-	wg.Wait()
+	return result
 }
 

--- a/main.go
+++ b/main.go
@@ -182,7 +182,7 @@ func cmdRemote(args []string) {
 
 // cmdLs handles: wt ls
 func cmdLs(remoteOnly bool) {
-	all, enrichErr := discoverAll(remoteOnly)
+	all, fetched, enrichErr := discoverAll(remoteOnly)
 	if enrichErr != nil {
 		die("%v", enrichErr)
 	}
@@ -193,7 +193,8 @@ func cmdLs(remoteOnly bool) {
 		return
 	}
 
-	// Classify in parallel
+	// Classify in parallel. Each entry waits for its repo's fetch to complete,
+	// so fast-fetching repos start classification while slow ones are still fetching.
 	statuses := make([]string, len(all))
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 8)
@@ -203,6 +204,7 @@ func cmdLs(remoteOnly bool) {
 		go func(idx int, entry worktree.Entry) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			fetched.Wait(entry)
 			statuses[idx] = classifyStatus(entry)
 		}(i, e)
 	}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/ellistarn/wt/pkg/ssh"
 )
@@ -78,9 +79,24 @@ func runGit(host, dir string, args ...string) (string, error) {
 	return strings.TrimSpace(out), err
 }
 
+// defaultBranchCache avoids redundant git calls for the same repo.
+// Key: "host\x00repo", Value: branch name string.
+var defaultBranchCache sync.Map
+
 // DefaultBranch returns the default branch name (e.g., "main" or "master")
 // by checking refs/remotes/origin/HEAD, then probing main and master.
+// Results are cached per (host, repo) for the lifetime of the process.
 func DefaultBranch(host, repo string) string {
+	cacheKey := host + "\x00" + repo
+	if v, ok := defaultBranchCache.Load(cacheKey); ok {
+		return v.(string)
+	}
+	result := defaultBranchUncached(host, repo)
+	defaultBranchCache.Store(cacheKey, result)
+	return result
+}
+
+func defaultBranchUncached(host, repo string) string {
 	out, err := runGit(host, repo, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if err == nil {
 		// refs/remotes/origin/main -> main

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -20,8 +20,14 @@ func Host() (string, error) {
 }
 
 // Run executes a command on the remote host via SSH, passing cmd via stdin to bash.
+// Uses ControlMaster to multiplex connections — the first call to a given host
+// pays the full TCP+auth cost; subsequent calls within ControlPersist reuse it.
 func Run(host, cmd string) (string, error) {
-	c := exec.Command("ssh", host, "bash")
+	c := exec.Command("ssh",
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=/tmp/wt-ssh-%r@%h:%p",
+		"-o", "ControlPersist=60",
+		host, "bash")
 	c.Stdin = strings.NewReader(cmd)
 	out, err := c.CombinedOutput()
 	if err != nil {

--- a/rm.go
+++ b/rm.go
@@ -66,7 +66,7 @@ func isRemovable(status string) bool {
 }
 
 func cmdRmBatch(remoteOnly bool) {
-	all, enrichErr := discoverAll(remoteOnly)
+	all, fetched, enrichErr := discoverAll(remoteOnly)
 	if enrichErr != nil {
 		die("cannot determine session status: %v", enrichErr)
 	}
@@ -92,6 +92,7 @@ func cmdRmBatch(remoteOnly bool) {
 		go func(idx int, entry worktree.Entry) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			fetched.Wait(entry)
 			statuses[idx] = classifyStatus(entry)
 		}(i, e)
 	}


### PR DESCRIPTION
## Summary

- **Per-repo fetch channels** — `discoverAll` kicks off `git fetch` per repo and returns immediately with done channels. Classification waits per-entry on its repo's fetch, so fast repos start classification while slow repos are still fetching. Previously fetch blocked all classification.
- **DefaultBranch cache** — `sync.Map` keyed by `(host, repo)` eliminates redundant `git symbolic-ref`/`rev-parse` calls when multiple worktrees share a repo (called from both `UniqueCommitCount` and `IsMerged`).
- **SSH ControlMaster** — First `ssh.Run` to a host pays full TCP+auth cost; subsequent calls within 60s multiplex over the existing connection via `/tmp/wt-ssh-%r@%h:%p`.