### PR TITLE
Log actual commands and output instead of human-written summaries

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -55,7 +55,7 @@ func findWorktree(name string) (worktree.Entry, bool) {
 // returned so callers can gate classification on each repo's fetch completing.
 // Returns any enrichment error — callers that make safety decisions must
 // check this; callers that only display can ignore it.
-func discoverAll(remoteOnly bool) ([]worktree.Entry, fetchResult, error) {
+func discoverAll(remoteOnly, fetch bool) ([]worktree.Entry, fetchResult, error) {
 	host := os.Getenv("WT_REMOTE_HOST")
 
 	localCh := make(chan []worktree.Entry, 1)
@@ -102,7 +102,12 @@ func discoverAll(remoteOnly bool) ([]worktree.Entry, fetchResult, error) {
 	var wg sync.WaitGroup
 	var localErr, remoteErr error
 
-	fetched := startFetchRepos(all)
+	var fetched fetchResult
+	if fetch {
+		fetched = startFetchRepos(all)
+	} else {
+		fetched = make(fetchResult)
+	}
 
 	if !remoteOnly {
 		wg.Add(1)

--- a/main.go
+++ b/main.go
@@ -73,7 +73,6 @@ func cmdLocal(args []string) {
 		if err := git.WorktreeAdd("", repo, name); err != nil {
 			die("failed to create worktree: %v", err)
 		}
-		fmt.Fprintf(os.Stderr, "created worktree %s\n", name)
 		if err := attach(serverURL, wtDir, ""); err != nil {
 			die("%v", err)
 		}
@@ -159,7 +158,6 @@ func cmdRemote(args []string) {
 	if err := git.WorktreeAdd(host, repo, name); err != nil {
 		die("failed to create remote worktree: %v", err)
 	}
-	fmt.Fprintf(os.Stderr, "created worktree %s on %s\n", name, host)
 	if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
 		die("%v", err)
 	}
@@ -182,7 +180,7 @@ func cmdRemote(args []string) {
 
 // cmdLs handles: wt ls
 func cmdLs(remoteOnly bool) {
-	all, fetched, enrichErr := discoverAll(remoteOnly)
+	all, fetched, enrichErr := discoverAll(remoteOnly, true)
 	if enrichErr != nil {
 		die("%v", enrichErr)
 	}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -40,17 +40,13 @@ func RepoRoot(host string, dir ...string) (string, error) {
 
 // WorktreeAdd creates a new worktree at <repo>/.worktrees/<name> on branch <name>.
 func WorktreeAdd(host, repo, name string) error {
-	if host == "" {
-		cmd := exec.Command("git", "worktree", "add", ".worktrees/"+name, "-b", name)
-		cmd.Dir = repo
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("%w: %s", err, out)
-		}
-		return nil
+	args := []string{"worktree", "add", ".worktrees/" + name, "-b", name}
+	out, err := runCapture(host, repo, args...)
+	if err != nil {
+		return err
 	}
-	script := fmt.Sprintf("cd '%s' && git worktree add '.worktrees/%s' -b '%s'", repo, name, name)
-	_, err := ssh.Run(host, script)
-	return err
+	logCmd(host, repo, out, args...)
+	return nil
 }
 
 // DirExists checks whether a directory exists, locally or over SSH.
@@ -166,22 +162,24 @@ func IsClean(host, dir string) bool {
 
 // Fetch updates remote tracking refs for a repo.
 func Fetch(host, repo string) {
-	runGit(host, repo, "fetch", "origin")
+	args := []string{"fetch", "origin"}
+	out, _ := runCapture(host, repo, args...)
+	if out != "" {
+		logCmd(host, repo, out, args...)
+	}
 }
 
 // Pull fetches with prune and fast-forwards the current branch. Used before
 // creating worktrees so they branch from the latest remote state. Uses
 // --ff-only to fail explicitly if the local branch has diverged.
 func Pull(host, repo string) error {
-	if host == "" {
-		cmd := exec.Command("git", "-C", repo, "pull", "--ff-only", "--prune")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("%w: %s", err, out)
-		}
-		return nil
+	args := []string{"pull", "--ff-only", "--prune"}
+	out, err := runCapture(host, repo, args...)
+	if err != nil {
+		return err
 	}
-	_, err := runGit(host, repo, "pull", "--ff-only", "--prune")
-	return err
+	logCmd(host, repo, out, args...)
+	return nil
 }
 
 // WorktreeRemove removes the worktree directory and deletes the branch.
@@ -189,9 +187,12 @@ func Pull(host, repo string) error {
 // (only if merged, safe delete).
 func WorktreeRemove(host, repo, name string) error {
 	wtPath := repo + "/.worktrees/" + name
-	if _, err := runGit(host, repo, "worktree", "remove", wtPath); err != nil {
+	args := []string{"worktree", "remove", wtPath}
+	out, err := runCapture(host, repo, args...)
+	if err != nil {
 		return fmt.Errorf("git worktree remove: %w", err)
 	}
+	logCmd(host, repo, out, args...)
 	// Best-effort branch delete. -d is safe (refuses unmerged branches).
 	// If it fails (branch doesn't exist, not merged), that's fine.
 	runGit(host, repo, "branch", "-d", name)
@@ -201,10 +202,41 @@ func WorktreeRemove(host, repo, name string) error {
 // WorktreeForceRemove removes the worktree and branch without safety checks.
 func WorktreeForceRemove(host, repo, name string) error {
 	wtPath := repo + "/.worktrees/" + name
-	if _, err := runGit(host, repo, "worktree", "remove", "--force", wtPath); err != nil {
+	args := []string{"worktree", "remove", "--force", wtPath}
+	out, err := runCapture(host, repo, args...)
+	if err != nil {
 		return fmt.Errorf("git worktree remove --force: %w", err)
 	}
+	logCmd(host, repo, out, args...)
 	// Force delete the branch regardless of merge status.
 	runGit(host, repo, "branch", "-D", name)
 	return nil
+}
+
+// runCapture runs a git command capturing combined stdout+stderr.
+// Used for side-effect commands where output indicates what changed.
+func runCapture(host, dir string, args ...string) (string, error) {
+	if host == "" {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		raw, err := cmd.CombinedOutput()
+		out := strings.TrimSpace(string(raw))
+		if err != nil {
+			return out, fmt.Errorf("%w: %s", err, out)
+		}
+		return out, nil
+	}
+	return runGit(host, dir, args...)
+}
+
+// logCmd prints a git command and its output to stderr.
+func logCmd(host, dir, output string, args ...string) {
+	cmd := "git -C " + dir + " " + strings.Join(args, " ")
+	if host != "" {
+		cmd = host + ": " + cmd
+	}
+	if output != "" {
+		fmt.Fprintf(os.Stderr, "%s\n%s\n", cmd, output)
+	} else {
+		fmt.Fprintf(os.Stderr, "%s\n", cmd)
+	}
 }

--- a/pkg/opencode/server.go
+++ b/pkg/opencode/server.go
@@ -43,6 +43,7 @@ func EnsureLocalServer() error {
 	}
 
 	cmd := exec.Command(binary, "serve", "--port", strconv.Itoa(port))
+	fmt.Fprintf(os.Stderr, "opencode serve --port %d\n", port)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 	if err == nil {
@@ -63,7 +64,6 @@ func EnsureLocalServer() error {
 
 	for i := 0; i < 20; i++ {
 		if healthProbe(url) == nil {
-			fmt.Fprintf(os.Stderr, "started opencode server on port %d\n", port)
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -83,6 +83,7 @@ func EnsureRemoteServer(host string) error {
 
 	port := ServerPort()
 	startCmd := fmt.Sprintf("$SHELL -ic 'nohup opencode serve --port %d </dev/null >/dev/null 2>&1 &'", port)
+	fmt.Fprintf(os.Stderr, "%s: opencode serve --port %d\n", host, port)
 	if _, err := ssh.Run(host, startCmd); err != nil {
 		// Race — someone else may have started it.
 		if healthProbe(tunnelURL) == nil {
@@ -93,7 +94,6 @@ func EnsureRemoteServer(host string) error {
 
 	for i := 0; i < 20; i++ {
 		if healthProbe(tunnelURL) == nil {
-			fmt.Fprintf(os.Stderr, "started remote opencode server via %s\n", host)
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -84,6 +84,7 @@ func EnsureTunnel(host string, localPort, remotePort int) error {
 		return nil
 	}
 	cmd := exec.Command("ssh", "-fNL", fmt.Sprintf("%d:localhost:%d", localPort, remotePort), host)
+	fmt.Fprintf(os.Stderr, "ssh -fNL %d:localhost:%d %s\n", localPort, remotePort, host)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Another process may have started the tunnel between our health
 		// check and this SSH invocation (race on "address already in use").
@@ -95,7 +96,6 @@ func EnsureTunnel(host string, localPort, remotePort int) error {
 	// Wait for the tunnel to accept connections.
 	for i := 0; i < 20; i++ {
 		if tunnelHealthy(localPort) {
-			fmt.Fprintf(os.Stderr, "started SSH tunnel to %s (localhost:%d)\n", host, localPort)
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/rm.go
+++ b/rm.go
@@ -66,7 +66,7 @@ func isRemovable(status string) bool {
 }
 
 func cmdRmBatch(remoteOnly bool) {
-	all, fetched, enrichErr := discoverAll(remoteOnly)
+	all, fetched, enrichErr := discoverAll(remoteOnly, false)
 	if enrichErr != nil {
 		die("cannot determine session status: %v", enrichErr)
 	}


### PR DESCRIPTION
## Summary
- Replace human-written log summaries ("created worktree", "pulled", "started SSH tunnel") with the actual commands being run and their output
- Only log when there's a side effect: `git fetch` is silent on noop during `wt ls`; `git pull` always logs (including "Already up to date")
- Remove `git fetch` from the `wt rm` path — `wt ls` is the discovery command; `wt rm` acts on what's already known
- Introduce `runCapture` to unify local/remote command execution for side-effect commands, eliminating duplicated local/remote branching in 5 functions