### PR TITLE
Add blank line before worktree table output

### DIFF
--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -29,6 +29,7 @@ func PrintTable(rows []Row) {
 	if len(rows) == 0 {
 		return
 	}
+	fmt.Println()
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tREPO\tTOKENS\tACTIVITY\tAGE\n")
 


### PR DESCRIPTION
## Summary
- Adds a `fmt.Println()` before the worktree table so git command output is visually separated from the table header.