### PR TITLE
wt ls: 7.2s → 3.0s — parallel walk, batch SSH classify, tunnel mux

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -191,22 +190,7 @@ func cmdLs(remoteOnly bool) {
 		return
 	}
 
-	// Classify in parallel. Each entry waits for its repo's fetch to complete,
-	// so fast-fetching repos start classification while slow ones are still fetching.
-	statuses := make([]string, len(all))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 8)
-	for i, e := range all {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(idx int, entry worktree.Entry) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			fetched.Wait(entry)
-			statuses[idx] = classifyStatus(entry)
-		}(i, e)
-	}
-	wg.Wait()
+	statuses := classifyAll(all, fetched)
 
 	rows := make([]display.Row, len(all))
 	for i, e := range all {

--- a/pkg/discover/local.go
+++ b/pkg/discover/local.go
@@ -22,11 +22,10 @@ func ListLocal() []worktree.Entry {
 
 	// Find .worktrees directories by walking with os.ReadDir, which uses
 	// the d_type field from readdir to check IsDir() without stat syscalls.
-	// The callback is thread-safe because the walk parallelizes at depth 0.
 	var repos []string
 	seen := make(map[string]bool)
 	var repoMu sync.Mutex
-	findWorktreeDirs(home, 0, 10, func(repo string) {
+	findWorktreeDirs(home, 10, 16, func(repo string) {
 		repoMu.Lock()
 		defer repoMu.Unlock()
 		if !seen[repo] {
@@ -63,10 +62,72 @@ func ListLocal() []worktree.Entry {
 //     directories (go/src/, github.com/org/) have low fan-out; only
 //     caches and artifact stores (Go module cache, node_modules) have
 //     hundreds of siblings.
-func findWorktreeDirs(dir string, depth, maxDepth int, fn func(repo string)) {
+//
+// A fixed pool of workers processes a directory queue so wall time scales
+// with tree depth rather than total directory count, without goroutine
+// explosion.
+func findWorktreeDirs(root string, maxDepth, workers int, fn func(repo string)) {
+	type item struct {
+		dir   string
+		depth int
+	}
+
+	var mu sync.Mutex
+	queue := []item{{root, 0}}
+	active := 0
+	wake := sync.NewCond(&mu)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			for {
+				mu.Lock()
+				for len(queue) == 0 && active > 0 {
+					wake.Wait()
+				}
+				if len(queue) == 0 {
+					mu.Unlock()
+					wake.Broadcast()
+					return
+				}
+				it := queue[0]
+				queue = queue[1:]
+				active++
+				mu.Unlock()
+
+				children := walkDir(it.dir, it.depth, fn)
+				if it.depth < maxDepth {
+					mu.Lock()
+					for _, name := range children {
+						queue = append(queue, item{filepath.Join(it.dir, name), it.depth + 1})
+					}
+					active--
+					mu.Unlock()
+					wake.Broadcast()
+				} else {
+					mu.Lock()
+					active--
+					mu.Unlock()
+					wake.Broadcast()
+				}
+			}
+		}()
+	}
+
+	// Wait for all workers to finish.
+	mu.Lock()
+	for active > 0 || len(queue) > 0 {
+		wake.Wait()
+	}
+	mu.Unlock()
+	wake.Broadcast()
+}
+
+// walkDir reads one directory and returns the child directory names to recurse
+// into after applying pruning rules. Found repos are reported via fn.
+func walkDir(dir string, depth int, fn func(repo string)) []string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return
+		return nil
 	}
 	hasGit := false
 	var children []string
@@ -89,30 +150,12 @@ func findWorktreeDirs(dir string, depth, maxDepth int, fn func(repo string)) {
 	}
 
 	if hasGit && depth > 0 {
-		return
+		return nil
 	}
 	if len(children) > 100 {
-		return
+		return nil
 	}
-	// Parallelize at the walk root — each top-level directory under $HOME
-	// gets its own goroutine so heavy subtrees don't block the rest.
-	if depth == 0 {
-		var wg sync.WaitGroup
-		for _, name := range children {
-			wg.Add(1)
-			go func(n string) {
-				defer wg.Done()
-				findWorktreeDirs(filepath.Join(dir, n), depth+1, maxDepth, fn)
-			}(name)
-		}
-		wg.Wait()
-		return
-	}
-	for _, name := range children {
-		if depth < maxDepth {
-			findWorktreeDirs(filepath.Join(dir, name), depth+1, maxDepth, fn)
-		}
-	}
+	return children
 }
 
 // listInRepo lists worktrees within a single local repo.

--- a/pkg/discover/remote.go
+++ b/pkg/discover/remote.go
@@ -11,22 +11,26 @@ import (
 )
 
 // ListRemote finds all worktrees on the remote host.
-// Uses find to walk the home directory (no depth limit from hardcoded globs),
-// prunes hidden dirs for speed, and collects worktree metadata including
-// timestamps in a single SSH call.
+// Fans out find across top-level home directories in parallel so wall time
+// scales with tree depth, not breadth — matching the local walk strategy.
+// Collects worktree metadata including timestamps in a single SSH call.
 func ListRemote(host string) ([]worktree.Entry, error) {
 	script := `
 set -eu
 home=$(cd "$HOME" && pwd -P)
-find "$home" -maxdepth 10 -type d \( -name .worktrees -print -prune -o -name '.*' -prune \) | while IFS= read -r wt_dir; do
-    repo="${wt_dir%/.worktrees}"
+
+# Parallel find: fan out across top-level dirs, same as local worker pool.
+# Writes to pipe are atomic for lines < PIPE_BUF (4096), so concurrent
+# finds produce clean output.
+process_repo() {
+    repo="$1"
     if [ -d "$repo/.git" ] || [ -f "$repo/.git" ]; then
         git -C "$repo" worktree list --porcelain 2>/dev/null | awk -v repo="$repo" '
             /^worktree / { wt=$2 }
             /^branch / {
                 br=$2; sub(/^refs\/heads\//, "", br)
                 if (wt ~ /\/.worktrees\//) {
-				    cmd = "stat -c %Y \"" wt "/.git\" 2>/dev/null || stat -f %m \"" wt "/.git\" 2>/dev/null || echo 0"
+                    cmd = "stat -c %Y \"" wt "/.git\" 2>/dev/null || stat -f %m \"" wt "/.git\" 2>/dev/null || echo 0"
                     cmd | getline ts
                     close(cmd)
                     print wt "\t" br "\t" repo "\t" ts
@@ -34,6 +38,21 @@ find "$home" -maxdepth 10 -type d \( -name .worktrees -print -prune -o -name '.*
             }
         '
     fi
+}
+
+{
+    # Check home root for .worktrees
+    [ -d "$home/.worktrees" ] && echo "$home/.worktrees"
+    # Fan out find across each top-level dir
+    for d in "$home"/*/; do
+        [ -d "$d" ] || continue
+        name=$(basename "$d")
+        case "$name" in .*) continue ;; esac
+        find "$d" -maxdepth 9 -type d \( -name .worktrees -print -prune -o -name '.*' -prune \) &
+    done
+    wait
+} | while IFS= read -r wt_dir; do
+    process_repo "${wt_dir%/.worktrees}"
 done
 `
 	out, err := ssh.Run(host, script)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -154,6 +154,109 @@ func IsMerged(host, repo, branch string) bool {
 	return mergeTree == targetTree
 }
 
+// ClassifyEntry holds the input for batch classification.
+type ClassifyEntry struct {
+	Dir    string // worktree directory
+	Repo   string // repo root
+	Branch string // branch name
+}
+
+// ClassifyResult holds the git classification for a single worktree.
+type ClassifyResult struct {
+	Clean  bool // no modified, staged, or untracked files
+	Unique int  // commits on branch not on origin/<default>
+	Merged bool // branch changes incorporated into origin/<default>
+}
+
+// ClassifyBatch classifies multiple remote worktrees in a single SSH call.
+// Replicates the logic of IsClean + UniqueCommitCount + IsMerged but runs
+// all git commands on the remote host in one round-trip.
+func ClassifyBatch(host string, entries []ClassifyEntry) []ClassifyResult {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Build heredoc with one entry per line: dir\trepo\tbranch
+	var heredoc strings.Builder
+	for _, e := range entries {
+		fmt.Fprintf(&heredoc, "%s\t%s\t%s\n", e.Dir, e.Repo, e.Branch)
+	}
+
+	script := `
+set -eu
+
+default_branch() {
+    repo="$1"
+    ref=$(git -C "$repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) && { echo "${ref##*/}"; return; }
+    git -C "$repo" rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1 && { echo main; return; }
+    git -C "$repo" rev-parse --verify refs/remotes/origin/master >/dev/null 2>&1 && { echo master; return; }
+    echo main
+}
+
+# Cache default branch per repo
+declare -A def_cache
+
+while IFS=$'\t' read -r dir repo branch; do
+    [ -z "$dir" ] && continue
+
+    # IsClean
+    status=$(git -C "$dir" status --porcelain 2>/dev/null) || status=""
+    if [ -n "$status" ]; then
+        clean=false
+    else
+        clean=true
+    fi
+
+    # DefaultBranch (cached per repo)
+    if [ -z "${def_cache[$repo]+x}" ]; then
+        def_cache[$repo]=$(default_branch "$repo")
+    fi
+    def="${def_cache[$repo]}"
+
+    # UniqueCommitCount
+    unique=$(git -C "$repo" rev-list --count "origin/$def..$branch" 2>/dev/null) || unique=0
+
+    # IsMerged (only if unique > 0)
+    merged=false
+    if [ "$unique" -gt 0 ] 2>/dev/null; then
+        if git -C "$repo" merge-base --is-ancestor "$branch" "origin/$def" 2>/dev/null; then
+            merged=true
+        else
+            merge_tree=$(git -C "$repo" merge-tree --write-tree "origin/$def" "$branch" 2>/dev/null) || merge_tree=""
+            target_tree=$(git -C "$repo" rev-parse "origin/${def}^{tree}" 2>/dev/null) || target_tree=""
+            if [ -n "$merge_tree" ] && [ "$merge_tree" = "$target_tree" ]; then
+                merged=true
+            fi
+        fi
+    fi
+
+    printf '%s\t%s\t%s\n' "$clean" "$unique" "$merged"
+done << 'ENTRIES'
+` + heredoc.String() + `ENTRIES
+`
+	out, err := ssh.Run(host, script)
+	if err != nil {
+		// Fallback: return empty results (caller will get zero values)
+		return make([]ClassifyResult, len(entries))
+	}
+
+	results := make([]ClassifyResult, len(entries))
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for i, line := range lines {
+		if i >= len(entries) {
+			break
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) < 3 {
+			continue
+		}
+		results[i].Clean = parts[0] == "true"
+		results[i].Unique, _ = strconv.Atoi(parts[1])
+		results[i].Merged = parts[2] == "true"
+	}
+	return results
+}
+
 // IsClean returns true if the worktree has no modified, staged, or untracked files.
 func IsClean(host, dir string) bool {
 	out, err := runGit(host, dir, "status", "--porcelain")

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -19,14 +19,15 @@ func Host() (string, error) {
 	return host, nil
 }
 
+// controlPath is the shared SSH mux socket path. The tunnel (EnsureTunnel)
+// creates the mux master; all other SSH calls (Run) reuse it.
+const controlPath = "/tmp/wt-ssh-%r@%h:%p"
+
 // Run executes a command on the remote host via SSH, passing cmd via stdin to bash.
-// Uses ControlMaster to multiplex connections — the first call to a given host
-// pays the full TCP+auth cost; subsequent calls within ControlPersist reuse it.
+// Reuses the tunnel's mux socket if available; falls back to a direct connection.
 func Run(host, cmd string) (string, error) {
 	c := exec.Command("ssh",
-		"-o", "ControlMaster=auto",
-		"-o", "ControlPath=/tmp/wt-ssh-%r@%h:%p",
-		"-o", "ControlPersist=60",
+		"-o", "ControlPath="+controlPath,
 		host, "bash")
 	c.Stdin = strings.NewReader(cmd)
 	out, err := c.CombinedOutput()
@@ -83,7 +84,10 @@ func EnsureTunnel(host string, localPort, remotePort int) error {
 	if tunnelHealthy(localPort) {
 		return nil
 	}
-	cmd := exec.Command("ssh", "-fNL", fmt.Sprintf("%d:localhost:%d", localPort, remotePort), host)
+	cmd := exec.Command("ssh",
+		"-o", "ControlMaster=yes",
+		"-o", "ControlPath="+controlPath,
+		"-fNL", fmt.Sprintf("%d:localhost:%d", localPort, remotePort), host)
 	fmt.Fprintf(os.Stderr, "ssh -fNL %d:localhost:%d %s\n", localPort, remotePort, host)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Another process may have started the tunnel between our health

--- a/rm.go
+++ b/rm.go
@@ -26,6 +26,83 @@ func cmdRm(args []string, remoteOnly bool) {
 	}
 }
 
+// classifyAll classifies all entries, batching remote entries into a single
+// SSH call per host and classifying local entries in parallel goroutines.
+func classifyAll(all []worktree.Entry, fetched fetchResult) []string {
+	statuses := make([]string, len(all))
+
+	type remoteEntry struct {
+		idx   int
+		entry worktree.Entry
+	}
+	remoteByHost := make(map[string][]remoteEntry)
+	var localIdxs []int
+	for i, e := range all {
+		if e.Remote {
+			remoteByHost[hostFor(e)] = append(remoteByHost[hostFor(e)], remoteEntry{i, e})
+		} else {
+			localIdxs = append(localIdxs, i)
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	// Remote: wait for fetches, then one SSH call per host.
+	for host, entries := range remoteByHost {
+		wg.Add(1)
+		go func(host string, entries []remoteEntry) {
+			defer wg.Done()
+			seen := make(map[string]bool)
+			for _, re := range entries {
+				if !seen[re.entry.Repo] {
+					seen[re.entry.Repo] = true
+					fetched.Wait(re.entry)
+				}
+			}
+			var batchEntries []git.ClassifyEntry
+			var batchIdxs []int
+			for _, re := range entries {
+				e := re.entry
+				if e.Attached {
+					statuses[re.idx] = "attached"
+					continue
+				}
+				if e.Status == "working" {
+					statuses[re.idx] = "working"
+					continue
+				}
+				batchEntries = append(batchEntries, git.ClassifyEntry{
+					Dir:    e.Dir,
+					Repo:   e.Repo,
+					Branch: e.Name,
+				})
+				batchIdxs = append(batchIdxs, re.idx)
+			}
+			results := git.ClassifyBatch(host, batchEntries)
+			for j, r := range results {
+				idx := batchIdxs[j]
+				statuses[idx] = classifyFromResult(all[idx], r.Clean, r.Unique, r.Merged)
+			}
+		}(host, entries)
+	}
+
+	// Local: parallel goroutines.
+	sem := make(chan struct{}, 8)
+	for _, i := range localIdxs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, entry worktree.Entry) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			fetched.Wait(entry)
+			statuses[idx] = classifyStatus(entry)
+		}(i, all[i])
+	}
+
+	wg.Wait()
+	return statuses
+}
+
 // classifyStatus returns the single highest-priority status for a worktree.
 // Priority: attached > working > dirty > merged > committed > idle > stale > empty.
 func classifyStatus(e worktree.Entry) string {
@@ -60,6 +137,28 @@ func classifyStatus(e worktree.Entry) string {
 	return "idle"
 }
 
+// classifyFromResult applies the same priority logic as classifyStatus but
+// uses pre-computed git results (from a batch SSH call) instead of making
+// individual git calls.
+func classifyFromResult(e worktree.Entry, clean bool, unique int, merged bool) string {
+	if !clean {
+		return "dirty"
+	}
+	if unique > 0 {
+		if merged {
+			return "merged"
+		}
+		return "committed"
+	}
+	if e.SessionID == "" {
+		return "empty"
+	}
+	if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
+		return "stale"
+	}
+	return "idle"
+}
+
 // isRemovable returns true if a status indicates the worktree is safe to remove.
 func isRemovable(status string) bool {
 	return status == "merged" || status == "stale" || status == "empty"
@@ -82,21 +181,7 @@ func cmdRmBatch(remoteOnly bool) {
 		errMsg string
 	}
 
-	// Classify in parallel
-	statuses := make([]string, len(all))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 8)
-	for i, e := range all {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(idx int, entry worktree.Entry) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			fetched.Wait(entry)
-			statuses[idx] = classifyStatus(entry)
-		}(i, e)
-	}
-	wg.Wait()
+	statuses := classifyAll(all, fetched)
 
 	// Remove sequentially
 	var results []result


### PR DESCRIPTION
## Summary

Four profiled changes to `wt ls` (and `wt rm`) latency:

1. **Local walk: 4.1s → 1.0s** — 16-worker pool replaces depth-0-only goroutine fanout. Benchmarked at 1/4/8/16/32/64/128 workers; plateaus at 16 on APFS.

2. **Remote walk: 1.4s → 0.6s** — Parallel `find` across top-level dirs via background jobs in the remote bash script.

3. **SSH mux: 2.8s → 60ms** — Tunnel owns `ControlMaster=yes`; `ssh.Run` uses `ControlPath` only. Mux socket lives as long as the tunnel (no ControlPersist expiry).

4. **Remote classify: ~50 SSH calls → 1** — `ClassifyBatch` runs all git classification (status, rev-list, merge-base, merge-tree) in a single SSH call per host. `classifyAll` extracted as shared path for `cmdLs` and `cmdRmBatch`.

End-to-end median: **7.2s → 3.0s** (warm SSH, interleaved old/new benchmark).