### PR TITLE
Prefix command echo lines with "> " to visually separate commands from output

### DIFF
--- a/pkg/display/log.go
+++ b/pkg/display/log.go
@@ -1,0 +1,18 @@
+package display
+
+import (
+	"fmt"
+	"os"
+)
+
+// LogCmd prints a command invocation to stderr with a prompt prefix.
+func LogCmd(line string) {
+	fmt.Fprintf(os.Stderr, "> %s\n", line)
+}
+
+// LogOutput prints command output to stderr.
+func LogOutput(output string) {
+	if output != "" {
+		fmt.Fprintln(os.Stderr, output)
+	}
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ellistarn/wt/pkg/display"
 	"github.com/ellistarn/wt/pkg/ssh"
 )
 
@@ -337,9 +338,6 @@ func logCmd(host, dir, output string, args ...string) {
 	if host != "" {
 		cmd = host + ": " + cmd
 	}
-	if output != "" {
-		fmt.Fprintf(os.Stderr, "%s\n%s\n", cmd, output)
-	} else {
-		fmt.Fprintf(os.Stderr, "%s\n", cmd)
-	}
+	display.LogCmd(cmd)
+	display.LogOutput(output)
 }

--- a/pkg/opencode/server.go
+++ b/pkg/opencode/server.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ellistarn/wt/pkg/display"
 	"github.com/ellistarn/wt/pkg/ssh"
 )
 
@@ -43,7 +44,7 @@ func EnsureLocalServer() error {
 	}
 
 	cmd := exec.Command(binary, "serve", "--port", strconv.Itoa(port))
-	fmt.Fprintf(os.Stderr, "opencode serve --port %d\n", port)
+	display.LogCmd(fmt.Sprintf("opencode serve --port %d", port))
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 	if err == nil {
@@ -83,7 +84,7 @@ func EnsureRemoteServer(host string) error {
 
 	port := ServerPort()
 	startCmd := fmt.Sprintf("$SHELL -ic 'nohup opencode serve --port %d </dev/null >/dev/null 2>&1 &'", port)
-	fmt.Fprintf(os.Stderr, "%s: opencode serve --port %d\n", host, port)
+	display.LogCmd(fmt.Sprintf("%s: opencode serve --port %d", host, port))
 	if _, err := ssh.Run(host, startCmd); err != nil {
 		// Race — someone else may have started it.
 		if healthProbe(tunnelURL) == nil {

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/ellistarn/wt/pkg/display"
 )
 
 // Host returns WT_REMOTE_HOST or an error if unset.
@@ -88,7 +90,7 @@ func EnsureTunnel(host string, localPort, remotePort int) error {
 		"-o", "ControlMaster=yes",
 		"-o", "ControlPath="+controlPath,
 		"-fNL", fmt.Sprintf("%d:localhost:%d", localPort, remotePort), host)
-	fmt.Fprintf(os.Stderr, "ssh -fNL %d:localhost:%d %s\n", localPort, remotePort, host)
+	display.LogCmd(fmt.Sprintf("ssh -fNL %d:localhost:%d %s", localPort, remotePort, host))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Another process may have started the tunnel between our health
 		// check and this SSH invocation (race on "address already in use").


### PR DESCRIPTION
## Summary

- Prefix all command invocations logged to stderr with `> ` so commands are visually distinct from their output
- Centralize command/output logging in `display.LogCmd` and `display.LogOutput` helpers
- Applied consistently across git, opencode serve, and ssh tunnel command echoes

### Before
```
git -C /repo push origin branch
To github.com:user/repo.git
 * [new branch]  branch -> branch
git -C /repo worktree remove ...
```

### After
```
> git -C /repo push origin branch
To github.com:user/repo.git
 * [new branch]  branch -> branch
> git -C /repo worktree remove ...
```