### PR TITLE
Only print blank line before table when commands were logged

### DIFF
--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -29,7 +29,9 @@ func PrintTable(rows []Row) {
 	if len(rows) == 0 {
 		return
 	}
-	fmt.Println()
+	if HasLogged() {
+		fmt.Println()
+	}
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
 	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tREPO\tTOKENS\tACTIVITY\tAGE\n")
 

--- a/pkg/display/log.go
+++ b/pkg/display/log.go
@@ -3,16 +3,25 @@ package display
 import (
 	"fmt"
 	"os"
+	"sync/atomic"
 )
+
+// logged tracks whether any command output has been written to stderr.
+var logged atomic.Bool
+
+// HasLogged reports whether any command output was emitted.
+func HasLogged() bool { return logged.Load() }
 
 // LogCmd prints a command invocation to stderr with a prompt prefix.
 func LogCmd(line string) {
+	logged.Store(true)
 	fmt.Fprintf(os.Stderr, "> %s\n", line)
 }
 
 // LogOutput prints command output to stderr.
 func LogOutput(output string) {
 	if output != "" {
+		logged.Store(true)
 		fmt.Fprintln(os.Stderr, output)
 	}
 }


### PR DESCRIPTION
## Summary
- Commit 67720e8 added an unconditional `fmt.Println()` before the worktree table to visually separate command output from the table header. When no commands run (e.g. `wt ls` with everything cached), this produces a spurious leading blank line.
- Track whether `LogCmd`/`LogOutput` have emitted output via an `atomic.Bool` and only print the separator when there is something to separate.
- Uses `atomic.Bool` because `LogCmd`/`LogOutput` are called from concurrent goroutines (fetch, enrichment).