### PR TITLE
Shorten worktree names from MMDDTHHmm-NNNNN to 7 hex chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Worktree session manager for [OpenCode](https://opencode.ai).
 ```
 $ wt ls
 WORKTREE            TITLE                              STATUS    ACTIVITY  TOKENS  REPO                                    AGE
-0424T0900-31337     Rewrite Linux scheduler in Rust     attached  now       380k    /home/torvalds/.../linux/kernel          3h
-0421T1030-00001     Implement quantum-safe cryptography working   now       240k    [remote] /home/satoshi/.../bitcoin/src   3d
-1213T0800-42069     Autonomous drone delivery           working   now       85k     /home/bezos/.../amazon/prime-air         12y
-0423T1600-12345     Add exceptions to Go                idle      6h        45k     /home/robpike/.../golang/go              1d
-1215T0900-80085     Actually open OpenAI                idle      10y       120k    /home/altman/.../openai/models           10y
-0423T0900-99999     -                                   -         -         -       /home/user/.../acme/toolkit             1d
+a3f8c12     Rewrite Linux scheduler in Rust     attached  now       380k    /home/torvalds/.../linux/kernel          3h
+b7e2a09     Implement quantum-safe cryptography working   now       240k    [remote] /home/satoshi/.../bitcoin/src   3d
+e1d4b83     Autonomous drone delivery           working   now       85k     /home/bezos/.../amazon/prime-air         12y
+c9a1f57     Add exceptions to Go                idle      6h        45k     /home/robpike/.../golang/go              1d
+d5b8e24     Actually open OpenAI                idle      10y       120k    /home/altman/.../openai/models           10y
+f2c7d91     -                                   -         -         -       /home/user/.../acme/toolkit             1d
 ```
 
 ## Usage

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -212,11 +212,11 @@ checking the working tree and branch against `origin/<default>`.
 
 ```
 WORKTREE            STATUS       TITLE                           REPO                              TOKENS  ACTIVITY  AGE
-0423T1430-12847     attached     Fix auth handler validation      [remote] /home/user/.../acme/api   150k    now       3h
-0423T1600-4419      committed    Refactor config parser           /Users/user/.../acme/api           42k     5m        1d
-0423T1700-8812      working      Migrate database schema          [remote] /home/user/.../acme/api   12k     now       2h
-0423T0900-2210      merged *     Add retry logic                  /Users/user/.../acme/api           80k     1h        2d
-0421T1100-5531      empty *      -                                [remote] /home/user/.../acme/web   -       -         2d
+a3f8c12     attached     Fix auth handler validation      [remote] /home/user/.../acme/api   150k    now       3h
+b7e2a09     committed    Refactor config parser           /Users/user/.../acme/api           42k     5m        1d
+c9a1f57     working      Migrate database schema          [remote] /home/user/.../acme/api   12k     now       2h
+d5b8e24     merged *     Add retry logic                  /Users/user/.../acme/api           80k     1h        2d
+e1d4b83     empty *      -                                [remote] /home/user/.../acme/web   -       -         2d
 ```
 
 Columns:
@@ -255,7 +255,7 @@ commits. Attachment is detected by scanning local `opencode attach` processes.
 
 1. Laptop opens.
 2. `wt ls` shows everything in flight (ensures the server and tunnel as needed).
-3. `wt 0423T1430-12847` resumes (works for both local and remote worktrees).
+3. `wt a3f8c12` resumes (works for both local and remote worktrees).
 
 ## Assumptions
 

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -83,8 +83,8 @@ func TestPrintTable(t *testing.T) {
 	rows := []Row{
 		{
 			Entry: worktree.Entry{
-				Name:      "0424T0907-93511",
-				Dir:       "/home/user/src/github.com/acme/project/.worktrees/0424T0907-93511",
+				Name:      "a3f8c12",
+				Dir:       "/home/user/src/github.com/acme/project/.worktrees/a3f8c12",
 				Repo:      "/home/user/src/github.com/acme/project",
 				Status:    "idle",
 				Title:     "Fix auth handler",
@@ -96,8 +96,8 @@ func TestPrintTable(t *testing.T) {
 		},
 		{
 			Entry: worktree.Entry{
-				Name:      "0424T1035-627",
-				Dir:       "/home/user/src/github.com/acme/project/.worktrees/0424T1035-627",
+				Name:      "b7e2a09",
+				Dir:       "/home/user/src/github.com/acme/project/.worktrees/b7e2a09",
 				Repo:      "/home/user/src/github.com/acme/project",
 				CreatedAt: now.Add(-1 * time.Hour),
 			},
@@ -150,7 +150,7 @@ func TestPrintTable(t *testing.T) {
 	}
 
 	// Second row: empty status with * marker.
-	if !strings.Contains(lines[2], "0424T1035-627") {
+	if !strings.Contains(lines[2], "b7e2a09") {
 		t.Errorf("expected worktree name in row 2: %s", lines[2])
 	}
 	if !strings.Contains(lines[2], "empty *") {

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -239,7 +239,7 @@ func TestFetchSessionStatus_NoMessages(t *testing.T) {
 func TestEnrich_RegressionCrossProject(t *testing.T) {
 	session := Session{
 		ID:        "sess-1",
-		Directory: "/home/user/kro/.worktrees/0425T1457-57407",
+		Directory: "/home/user/kro/.worktrees/a3f8c12",
 		Title:     "fix auth bug",
 		Time: struct {
 			Created int64 `json:"created"`
@@ -267,12 +267,12 @@ func TestEnrich_RegressionCrossProject(t *testing.T) {
 
 	entries := []worktree.Entry{
 		{
-			Name: "0425T1457-57407",
-			Dir:  "/home/user/kro/.worktrees/0425T1457-57407",
+			Name: "a3f8c12",
+			Dir:  "/home/user/kro/.worktrees/a3f8c12",
 		},
 		{
-			Name: "0425T2308-84317",
-			Dir:  "/home/user/wt/.worktrees/0425T2308-84317", // no session for this one
+			Name: "b7e2a09",
+			Dir:  "/home/user/wt/.worktrees/b7e2a09", // no session for this one
 		},
 	}
 

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -1,8 +1,8 @@
 package worktree
 
 import (
-	"fmt"
-	"math/rand"
+	"crypto/rand"
+	"encoding/hex"
 	"sort"
 	"time"
 )
@@ -22,10 +22,15 @@ type Entry struct {
 	Attached  bool      // true if a TUI client is attached to this worktree
 }
 
-// GenerateName returns a timestamped random name for a new worktree.
+// GenerateName returns a short random hex name for a new worktree.
+// 7 hex chars = 28 bits of entropy (~268M namespace), sufficient for
+// collision-free operation across 100k+ worktrees.
 func GenerateName() string {
-	now := time.Now()
-	return fmt.Sprintf("%s-%d", now.Format("0102T1504"), rand.Intn(100000))
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(b[:])[:7]
 }
 
 // Sort sorts entries by most recent activity (UpdatedAt), newest first.

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -1,9 +1,26 @@
 package worktree
 
 import (
+	"regexp"
 	"testing"
 	"time"
 )
+
+func TestGenerateName(t *testing.T) {
+	hex7 := regexp.MustCompile(`^[0-9a-f]{7}$`)
+	seen := map[string]bool{}
+	for i := 0; i < 1000; i++ {
+		name := GenerateName()
+		if !hex7.MatchString(name) {
+			t.Fatalf("GenerateName() = %q, want 7 lowercase hex chars", name)
+		}
+		seen[name] = true
+	}
+	// With 268M namespace, 1000 names should all be unique.
+	if len(seen) != 1000 {
+		t.Errorf("got %d unique names out of 1000, expected all unique", len(seen))
+	}
+}
 
 func TestSort_ActivityBeforeNoActivity(t *testing.T) {
 	now := time.Now()


### PR DESCRIPTION
## Summary

- Replace timestamped naming (`0426T1118-57306`, 15 chars) with short random hex (`a3f8c12`, 7 chars)
- 28 bits of entropy gives a 268M namespace — sufficient for 100k+ worktrees with negligible collision probability
- Switch from `math/rand` to `crypto/rand` for proper randomness