### PR TITLE
Fix stale sessions showing no tokens, surface SSH classification errors

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -247,9 +247,10 @@ type ClassifyResult struct {
 // ClassifyBatch classifies multiple remote worktrees in a single SSH call.
 // Replicates the logic of IsClean + UniqueCommitCount + IsMerged but runs
 // all git commands on the remote host in one round-trip.
-func ClassifyBatch(host string, entries []ClassifyEntry) []ClassifyResult {
+// Returns an error if the SSH call fails entirely.
+func ClassifyBatch(host string, entries []ClassifyEntry) ([]ClassifyResult, error) {
 	if len(entries) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Build heredoc with one entry per line: dir\trepo\tbranch
@@ -325,8 +326,7 @@ done << 'ENTRIES'
 `
 	out, err := ssh.Run(host, script)
 	if err != nil {
-		// Fallback: return empty results (caller will get zero values)
-		return make([]ClassifyResult, len(entries))
+		return nil, fmt.Errorf("remote classify: %w", err)
 	}
 
 	results := make([]ClassifyResult, len(entries))
@@ -343,7 +343,7 @@ done << 'ENTRIES'
 		results[i].Unique, _ = strconv.Atoi(parts[1])
 		results[i].Merged = parts[2] == "true"
 	}
-	return results
+	return results, nil
 }
 
 // IsClean returns true if the worktree has no modified, staged, or untracked files.

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -289,3 +289,81 @@ func TestEnrich_RegressionCrossProject(t *testing.T) {
 		t.Errorf("entries[1].SessionID = %q, want empty", entries[1].SessionID)
 	}
 }
+
+// TestEnrich_RegressionStaleTokens verifies that stale sessions (UpdatedAt >
+// StaleThreshold) still get their Tokens field populated. Previously, the stale
+// check returned early before calling fetchSessionStatus, causing stale sessions
+// to show "-" for tokens even when the session had token data.
+func TestEnrich_RegressionStaleTokens(t *testing.T) {
+	staleTime := time.Now().Add(-StaleThreshold - time.Hour).UnixMilli()
+
+	session := Session{
+		ID:        "sess-stale",
+		Directory: "/home/user/wt/.worktrees/c4d9e01",
+		Title:     "stale session with tokens",
+		Time: struct {
+			Created int64 `json:"created"`
+			Updated int64 `json:"updated"`
+		}{Updated: staleTime},
+	}
+
+	messages := []message{
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "user"}},
+		{Info: struct {
+			Role   string `json:"role"`
+			Tokens struct {
+				Total int `json:"total"`
+			} `json:"tokens"`
+			Time struct {
+				Completed int64 `json:"completed"`
+			} `json:"time"`
+		}{Role: "assistant", Tokens: struct {
+			Total int `json:"total"`
+		}{Total: 42000}, Time: struct {
+			Completed int64 `json:"completed"`
+		}{Completed: staleTime}}},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/global/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+		dir := r.URL.Query().Get("directory")
+		if dir == session.Directory {
+			json.NewEncoder(w).Encode([]Session{session})
+		} else {
+			json.NewEncoder(w).Encode([]Session{})
+		}
+	})
+	mux.HandleFunc("/session/sess-stale/message", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(messages)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	entries := []worktree.Entry{
+		{
+			Name: "c4d9e01",
+			Dir:  "/home/user/wt/.worktrees/c4d9e01",
+		},
+	}
+
+	if err := Enrich(srv.URL, entries); err != nil {
+		t.Fatalf("Enrich: %v", err)
+	}
+	if entries[0].Status != "stale" {
+		t.Errorf("Status = %q, want %q", entries[0].Status, "stale")
+	}
+	if entries[0].Tokens != 42000 {
+		t.Errorf("Tokens = %d, want 42000 (stale sessions must still populate tokens)", entries[0].Tokens)
+	}
+}

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -102,7 +102,7 @@ func QuerySession(serverURL, directory string) (*Session, error) {
 
 // Enrich enriches worktree entries with session data from the OpenCode server.
 // Queries each entry's session by directory (crossing project boundaries) and
-// fetches message status for sessions that may be actively streaming.
+// fetches message status (token count and streaming state) for each session.
 func Enrich(serverURL string, entries []worktree.Entry) error {
 	if err := checkHealthFast(serverURL); err != nil {
 		return err
@@ -128,13 +128,13 @@ func Enrich(serverURL string, entries []worktree.Entry) error {
 			entries[i].Title = s.Title
 			entries[i].UpdatedAt = time.UnixMilli(s.Time.Updated)
 
+			status := fetchSessionStatus(serverURL, entries[i].SessionID)
+			entries[i].Tokens = status.tokens
+
 			if time.Since(entries[i].UpdatedAt) > StaleThreshold {
 				entries[i].Status = "stale"
 				return
 			}
-
-			status := fetchSessionStatus(serverURL, entries[i].SessionID)
-			entries[i].Tokens = status.tokens
 			if status.streaming {
 				entries[i].Status = "working"
 			} else {

--- a/rm.go
+++ b/rm.go
@@ -78,7 +78,11 @@ func classifyAll(all []worktree.Entry, fetched fetchResult) []string {
 				})
 				batchIdxs = append(batchIdxs, re.idx)
 			}
-			results := git.ClassifyBatch(host, batchEntries)
+			results, err := git.ClassifyBatch(host, batchEntries)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+				return
+			}
 			for j, r := range results {
 				idx := batchIdxs[j]
 				statuses[idx] = classifyFromResult(all[idx], r.Clean, r.Unique, r.Merged)
@@ -137,9 +141,10 @@ func classifyStatus(e worktree.Entry) string {
 	return "idle"
 }
 
-// classifyFromResult applies the same priority logic as classifyStatus but
-// uses pre-computed git results (from a batch SSH call) instead of making
-// individual git calls.
+// classifyFromResult classifies a worktree using pre-computed git results
+// (from a batch SSH call) instead of making individual git calls.
+// Unlike classifyStatus, this does NOT check Attached or working status —
+// callers must handle those cases before calling this function.
 func classifyFromResult(e worktree.Entry, clean bool, unique int, merged bool) string {
 	if !clean {
 		return "dirty"


### PR DESCRIPTION
## Summary
- Stale sessions (>12h inactive) skipped `fetchSessionStatus` entirely, causing token counts to show `-` even when the session had token data. Moved message fetch before the stale gate so tokens are always populated.
- `ClassifyBatch` now returns an error instead of silently producing zero-value `ClassifyResult` on SSH failure, which caused remote worktrees to be silently misclassified as "dirty".
- Fixed `classifyFromResult` docstring that falsely claimed parity with `classifyStatus` (it omits attached/working guards).
- Added regression test `TestEnrich_RegressionStaleTokens`.

## Root cause
The stale threshold early-return in `Enrich` (`session.go:131-133`) was an optimization that predated the token column. It skipped the entire `fetchSessionStatus` call, suppressing both streaming detection (correct — stale sessions can't be streaming) and token counts (incorrect — the design says tokens show `-` only when there's no session).

## Verified
`0424T2138-71651` now shows `223k` instead of `-`. All tests pass including the new regression test.