### PR TITLE
Replace Remote bool with Host string on worktree.Entry

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -142,10 +142,7 @@ func discoverAll(remoteOnly, fetch bool) ([]worktree.Entry, fetchResult, error) 
 
 // hostFor returns the SSH host for an entry, or "" for local entries.
 func hostFor(e worktree.Entry) string {
-	if e.Remote {
-		return os.Getenv("WT_REMOTE_HOST")
-	}
-	return ""
+	return e.Host
 }
 
 // fetchResult holds per-repo done channels from a non-blocking fetch.

--- a/main.go
+++ b/main.go
@@ -98,21 +98,17 @@ func cmdLocal(args []string) {
 		fmt.Fprintf(os.Stderr, "warning: pull failed: %v\n", err)
 	}
 
-	if !entry.Remote {
+	if entry.Host == "" {
 		sessionID := opencode.FindLatestSession(serverURL, entry.Dir)
 		if err := attach(serverURL, entry.Dir, sessionID); err != nil {
 			die("%v", err)
 		}
 		printExitRow(serverURL, entry)
 	} else {
-		host, err := ssh.Host()
-		if err != nil {
+		if err := ssh.EnsureTunnel(entry.Host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
 			die("%v", err)
 		}
-		if err := ssh.EnsureTunnel(host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
-			die("%v", err)
-		}
-		if err := opencode.EnsureRemoteServer(host); err != nil {
+		if err := opencode.EnsureRemoteServer(entry.Host); err != nil {
 			die("%v", err)
 		}
 		remoteURL := opencode.RemoteServerURL()
@@ -172,7 +168,7 @@ func cmdRemote(args []string) {
 		Name:      name,
 		Dir:       wtDir,
 		Repo:      repo,
-		Remote:    true,
+		Host:      host,
 		CreatedAt: time.Now(),
 	})
 }

--- a/pkg/discover/remote.go
+++ b/pkg/discover/remote.go
@@ -70,10 +70,10 @@ done
 			continue
 		}
 		e := worktree.Entry{
-			Dir:    parts[0],
-			Name:   path.Base(parts[0]),
-			Repo:   parts[2],
-			Remote: true,
+			Dir:  parts[0],
+			Name: path.Base(parts[0]),
+			Repo: parts[2],
+			Host: host,
 		}
 		if len(parts) >= 4 {
 			if ts, err := strconv.ParseInt(strings.TrimSpace(parts[3]), 10, 64); err == nil {

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -33,7 +33,7 @@ func PrintTable(rows []Row) {
 		fmt.Println()
 	}
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tREPO\tTOKENS\tACTIVITY\tAGE\n")
+	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tREPO\tHOST\tTOKENS\tACTIVITY\tAGE\n")
 
 	now := time.Now()
 	for _, r := range rows {
@@ -48,9 +48,13 @@ func PrintTable(rows []Row) {
 		if title == "" {
 			title = "-"
 		}
-		repo := formatRepo(e.Repo, e.Remote)
+		repo := formatRepo(e.Repo)
+		host := e.Host
+		if host == "" {
+			host = "-"
+		}
 		age := formatDuration(e.CreatedAt, now)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, repo, tokens, activity, age)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, repo, host, tokens, activity, age)
 	}
 
 	w.Flush()
@@ -105,18 +109,14 @@ func formatTokens(tokens int) string {
 	}
 }
 
-// formatRepo shortens the repo path to <home>/.../last/two and tags remote entries.
-func formatRepo(repo string, remote bool) string {
+// formatRepo shortens the repo path to ~/.../last/three segments.
+func formatRepo(repo string) string {
 	parts := strings.Split(repo, "/")
-	// Shorten: keep first 3 segments (e.g., "", "home", "user"), then .../, then last 2.
-	// Only shorten if there are more than 5 segments (home + at least 3 intermediate + 2 tail).
-	if len(parts) > 5 {
-		head := strings.Join(parts[:3], "/") // e.g., /home/user
-		tail := strings.Join(parts[len(parts)-2:], "/")
-		repo = head + "/.../" + tail
-	}
-	if remote {
-		return "[remote] " + repo
+	// Show last 3 segments with ~/... prefix when the path is long enough.
+	// e.g., /home/user/go/src/github.com/acme/project → ~/.../acme/project
+	if len(parts) > 4 {
+		tail := strings.Join(parts[len(parts)-3:], "/")
+		return "~/.../" + tail
 	}
 	return repo
 }

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -61,19 +61,16 @@ func TestFormatDuration(t *testing.T) {
 
 func TestFormatRepo(t *testing.T) {
 	tests := []struct {
-		repo   string
-		remote bool
-		want   string
+		repo string
+		want string
 	}{
-		{"/home/user/src/github.com/acme/project", false, "/home/user/.../acme/project"},
-		{"/home/user/src/github.com/acme/project", true, "[remote] /home/user/.../acme/project"},
-		{"/short/path", false, "/short/path"},
-		{"/short/path", true, "[remote] /short/path"},
+		{"/home/user/src/github.com/acme/project", "~/.../github.com/acme/project"},
+		{"/short/path", "/short/path"},
 	}
 	for _, tt := range tests {
-		got := formatRepo(tt.repo, tt.remote)
+		got := formatRepo(tt.repo)
 		if got != tt.want {
-			t.Errorf("formatRepo(%q, %v) = %q, want %q", tt.repo, tt.remote, got, tt.want)
+			t.Errorf("formatRepo(%q) = %q, want %q", tt.repo, got, tt.want)
 		}
 	}
 }
@@ -129,7 +126,7 @@ func TestPrintTable(t *testing.T) {
 
 	// Header should have the right columns.
 	header := lines[0]
-	for _, col := range []string{"WORKTREE", "STATUS", "TITLE", "ACTIVITY", "TOKENS", "REPO", "AGE"} {
+	for _, col := range []string{"WORKTREE", "STATUS", "TITLE", "ACTIVITY", "TOKENS", "REPO", "HOST", "AGE"} {
 		if !strings.Contains(header, col) {
 			t.Errorf("header missing column %q: %s", col, header)
 		}

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -9,10 +9,10 @@ import (
 
 // Entry represents a discovered worktree.
 type Entry struct {
-	Name      string    // branch/worktree name
-	Dir       string    // absolute path on the host where it lives
-	Repo      string    // repo root path
-	Remote    bool      // true if this worktree lives on the remote host
+	Name string // branch/worktree name
+	Dir  string // absolute path on the host where it lives
+	Repo string // repo root path
+	Host string // hostname where the worktree's server runs (empty = local)
 	CreatedAt time.Time // worktree creation time (from filesystem)
 	UpdatedAt time.Time // last session activity (from OpenCode)
 	SessionID string    // most recent OpenCode session ID (empty if none)

--- a/rm.go
+++ b/rm.go
@@ -38,8 +38,8 @@ func classifyAll(all []worktree.Entry, fetched fetchResult) []string {
 	remoteByHost := make(map[string][]remoteEntry)
 	var localIdxs []int
 	for i, e := range all {
-		if e.Remote {
-			remoteByHost[hostFor(e)] = append(remoteByHost[hostFor(e)], remoteEntry{i, e})
+		if e.Host != "" {
+			remoteByHost[e.Host] = append(remoteByHost[e.Host], remoteEntry{i, e})
 		} else {
 			localIdxs = append(localIdxs, i)
 		}


### PR DESCRIPTION
## Summary

- Replace `Remote bool` with `Host string` on `worktree.Entry`, making remote identity explicit data rather than a derived boolean
- `hostFor(e)` simplifies from env-var lookup to field read; display gains a HOST column, drops `[remote]` prefix
- `formatRepo` shortened to `~/.../last/three/segments` for compactness

## Motivation

Prepares the data model for multi-host topologies (pods). Today `Host` is populated from `WT_REMOTE_HOST`; in the future it will carry pod IDs. The routing logic (`entry.Host == ""` → local, otherwise SSH to `entry.Host`) generalizes naturally from 1 remote to N.