### PR TITLE
Shorten stale threshold from 12h to 4h

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -30,7 +30,7 @@ managed from within OpenCode, not by this tool.
 
 A session is **working** when the agent is actively generating a response,
 **idle** when the session exists but is not generating, and **stale** when the
-session has been idle for more than 12 hours. A worktree with no session has no
+session has been idle for more than 4 hours. A worktree with no session has no
 status.
 
 An **OpenCode server** is a persistent process running `opencode serve`. One
@@ -242,7 +242,7 @@ removed by `wt rm`.
 | `merged *` | Changes incorporated into `origin/<default>` |
 | `committed` | Unique commits not in `origin/<default>` |
 | `idle` | Session exists, no unique commits, recent |
-| `stale *` | Session inactive >12 hours, no unique commits |
+| `stale *` | Session inactive >4 hours, no unique commits |
 | `empty *` | No session was ever created |
 
 Session states (`attached`, `working`) take priority — the worktree is in active

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ Status:
   merged *    Changes incorporated into default branch
   committed   Unique commits not yet in default branch
   idle        Session exists, no unique commits
-  stale *     Session inactive >12 hours, no unique commits
+  stale *     Session inactive >4 hours, no unique commits
   empty *     No session was ever created
 
 Flags:

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -14,7 +14,7 @@ import (
 
 // StaleThreshold is the duration after which a session with no recent activity
 // is considered stale.
-const StaleThreshold = 12 * time.Hour
+const StaleThreshold = 4 * time.Hour
 
 // Session is the API response type from the OpenCode server.
 type Session struct {

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -202,7 +202,7 @@ func TestSSH_RemoteSessionQuery(t *testing.T) {
 		}
 	}
 
-	// wt rm should skip it (session exists, default 12h stale threshold)
+	// wt rm should skip it (session exists, default 4h stale threshold)
 	out = env.wt("-r", "rm", "--dry-run")
 	t.Log("SSH rm dry-run output:\n" + out)
 	assertContains(t, out, "ssh-session")


### PR DESCRIPTION
## Summary

- Reduces `StaleThreshold` from 12 hours to 4 hours so idle sessions are classified as stale sooner
- Updates design doc, CLI help text, and test comments to match