### PR TITLE
Add wt diff <name> to show changes on a worktree's branch

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -181,6 +181,16 @@ All read paths (ls, rm) fetch from origin to ensure remote-tracking refs are
 current. Removal deletes the worktree
 directory and the branch. Session history in the database is not touched.
 
+### `wt diff <name>`
+
+Show the changes on a worktree's branch. Computes the merge-base with
+`origin/<default>` and diffs against it, capturing both committed and
+uncommitted changes.
+
+Output: `--stat` summary printed directly (stays in scrollback), then the full
+diff piped through `less -R` when stdout is a terminal. When piped (e.g., to an
+LLM or file), the full diff is printed directly with no color and no pager.
+
 ### `wt ls`
 
 List all worktrees with their status. Local worktrees (all repos under `$HOME`)

--- a/main.go
+++ b/main.go
@@ -43,6 +43,10 @@ func main() {
 		cmdRm(remaining[1:], remote)
 		return
 	}
+	if len(remaining) > 0 && remaining[0] == "diff" {
+		cmdDiff(remaining[1:])
+		return
+	}
 
 	if remote {
 		cmdRemote(remaining)
@@ -198,6 +202,61 @@ func cmdLs(remoteOnly bool) {
 	display.PrintTable(rows)
 }
 
+// cmdDiff handles: wt diff <name>
+func cmdDiff(args []string) {
+	if len(args) == 0 {
+		die("usage: wt diff <name>")
+	}
+	name := args[0]
+	entry, ok := findWorktree(name)
+	if !ok {
+		die("worktree %q not found", name)
+	}
+	host := hostFor(entry)
+
+	stat, err := git.DiffStat(host, entry.Dir)
+	if err != nil {
+		die("diff: %v", err)
+	}
+	if stat == "" {
+		fmt.Println("No changes on this branch.")
+		return
+	}
+	fmt.Println(stat)
+
+	isTTY := isTerminal()
+	full, err := git.Diff(host, entry.Dir, isTTY)
+	if err != nil {
+		die("diff: %v", err)
+	}
+	if isTTY {
+		page(full)
+	} else {
+		fmt.Print(full)
+	}
+}
+
+// isTerminal reports whether stdout is connected to a terminal.
+func isTerminal() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// page displays content through less -R, preserving ANSI color codes.
+// Falls back to direct output if the pager is unavailable.
+func page(content string) {
+	cmd := exec.Command("less", "-R")
+	cmd.Stdin = strings.NewReader(content)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Print(content)
+	}
+}
+
 func printUsage() {
 	usage := strings.TrimSpace(`
 wt — worktree session manager
@@ -208,6 +267,7 @@ Usage:
   wt -r <path>              Create a new remote worktree and attach
   wt ls                     List all worktrees (local and remote)
   wt -r ls                  List remote worktrees only
+  wt diff <name>            Show changes on a worktree's branch
   wt rm                     Remove worktrees marked * in wt ls
   wt rm <name>              Remove a specific worktree
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -346,6 +346,48 @@ done << 'ENTRIES'
 	return results, nil
 }
 
+// DiffStat returns a --stat summary of changes on this branch vs the merge-base
+// with origin/<default>. Returns "" if there are no changes.
+func DiffStat(host, dir string) (string, error) {
+	def := DefaultBranch(host, dir)
+	if host != "" {
+		script := fmt.Sprintf(
+			`mb=$(git -C '%s' merge-base 'origin/%s' HEAD) && git -C '%s' diff --stat "$mb"`,
+			dir, def, dir,
+		)
+		out, err := ssh.Run(host, script)
+		return strings.TrimSpace(out), err
+	}
+	mb, err := runGit("", dir, "merge-base", "origin/"+def, "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("merge-base: %w", err)
+	}
+	return runGit("", dir, "diff", "--stat", mb)
+}
+
+// Diff returns the full diff of changes on this branch vs the merge-base
+// with origin/<default>. If color is true, ANSI color codes are included.
+func Diff(host, dir string, color bool) (string, error) {
+	def := DefaultBranch(host, dir)
+	colorFlag := "--color=never"
+	if color {
+		colorFlag = "--color=always"
+	}
+	if host != "" {
+		script := fmt.Sprintf(
+			`mb=$(git -C '%s' merge-base 'origin/%s' HEAD) && git -C '%s' diff '%s' "$mb"`,
+			dir, def, dir, colorFlag,
+		)
+		out, err := ssh.Run(host, script)
+		return strings.TrimSpace(out), err
+	}
+	mb, err := runGit("", dir, "merge-base", "origin/"+def, "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("merge-base: %w", err)
+	}
+	return runGit("", dir, "diff", colorFlag, mb)
+}
+
 // IsClean returns true if the worktree has no modified, staged, or untracked files.
 func IsClean(host, dir string) bool {
 	out, err := runGit(host, dir, "status", "--porcelain")

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -625,3 +625,52 @@ func TestRemote_HostUnreachable(t *testing.T) {
 	}
 	assertContains(t, out, "cannot resolve remote HOME")
 }
+
+// --- Diff tests ---
+
+func TestDiff_CommittedChanges(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wt := env.addWorktree("diff-test")
+	env.commitFile(wt, "feature.txt", "new feature content", "add feature")
+
+	out := env.wt("diff", "diff-test")
+	t.Log("output:\n" + out)
+
+	// Stat summary should list the changed file
+	assertContains(t, out, "feature.txt")
+	// Full diff should contain the file content
+	assertContains(t, out, "new feature content")
+}
+
+func TestDiff_NoChanges(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	env.addWorktree("diff-empty")
+
+	out := env.wt("diff", "diff-empty")
+	t.Log("output:\n" + out)
+
+	assertContains(t, out, "No changes on this branch.")
+}
+
+func TestDiff_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	out := env.wt("diff", "nonexistent")
+	t.Log("output:\n" + out)
+
+	assertContains(t, out, "not found")
+}


### PR DESCRIPTION
## Summary

- Adds `wt diff <name>` command that shows all changes (committed + uncommitted) on a worktree's branch relative to the merge-base with `origin/<default>`.
- Prints `--stat` summary directly (stays in scrollback), then pipes the full colored diff through `less -R` when stdout is a TTY. When piped (e.g., to an LLM), outputs the full diff directly with no color and no pager.
- Supports both local and remote worktrees via the existing `findWorktree` discovery and SSH execution paths.