### PR TITLE
Collapse REPO and HOST columns into single URI column

### DIFF
--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -123,7 +123,11 @@ func formatURI(host, repo string) string {
 	if host == "" {
 		host = "localhost"
 	}
-	return fmt.Sprintf("%s:%d%s", host, serverPort(), formatRepo(repo))
+	path := formatRepo(repo)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return fmt.Sprintf("%s:%d%s", host, serverPort(), path)
 }
 
 // serverPort returns the OpenCode server port (default 5096, overridden by WT_OPENCODE_PORT).

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -3,6 +3,7 @@ package display
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -33,7 +34,7 @@ func PrintTable(rows []Row) {
 		fmt.Println()
 	}
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tREPO\tHOST\tTOKENS\tACTIVITY\tAGE\n")
+	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tURI\tTOKENS\tACTIVITY\tAGE\n")
 
 	now := time.Now()
 	for _, r := range rows {
@@ -48,13 +49,9 @@ func PrintTable(rows []Row) {
 		if title == "" {
 			title = "-"
 		}
-		repo := formatRepo(e.Repo)
-		host := e.Host
-		if host == "" {
-			host = "-"
-		}
+		uri := formatURI(e.Host, e.Repo)
 		age := formatDuration(e.CreatedAt, now)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, repo, host, tokens, activity, age)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, uri, tokens, activity, age)
 	}
 
 	w.Flush()
@@ -119,6 +116,25 @@ func formatRepo(repo string) string {
 		return "~/.../" + tail
 	}
 	return repo
+}
+
+// formatURI combines host and repo into a single host:port/path string.
+func formatURI(host, repo string) string {
+	if host == "" {
+		host = "localhost"
+	}
+	return fmt.Sprintf("%s:%d%s", host, serverPort(), formatRepo(repo))
+}
+
+// serverPort returns the OpenCode server port (default 5096, overridden by WT_OPENCODE_PORT).
+// This duplicates opencode.ServerPort() to avoid an import cycle (opencode → display).
+func serverPort() int {
+	if s := os.Getenv("WT_OPENCODE_PORT"); s != "" {
+		if p, err := strconv.Atoi(s); err == nil {
+			return p
+		}
+	}
+	return 5096
 }
 
 func FormatAge(t time.Time, now time.Time) string {

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -82,9 +82,9 @@ func TestFormatURI(t *testing.T) {
 		want string
 	}{
 		// Local worktree (empty host) gets localhost.
-		{"", "/home/user/src/github.com/acme/project", "localhost:5096~/.../github.com/acme/project"},
+		{"", "/home/user/src/github.com/acme/project", "localhost:5096/~/.../github.com/acme/project"},
 		// Remote worktree keeps the provided host.
-		{"devbox", "/home/user/src/github.com/acme/project", "devbox:5096~/.../github.com/acme/project"},
+		{"devbox", "/home/user/src/github.com/acme/project", "devbox:5096/~/.../github.com/acme/project"},
 		// Short repo path passes through unshortened.
 		{"", "/short/path", "localhost:5096/short/path"},
 	}

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -75,6 +75,36 @@ func TestFormatRepo(t *testing.T) {
 	}
 }
 
+func TestFormatURI(t *testing.T) {
+	tests := []struct {
+		host string
+		repo string
+		want string
+	}{
+		// Local worktree (empty host) gets localhost.
+		{"", "/home/user/src/github.com/acme/project", "localhost:5096~/.../github.com/acme/project"},
+		// Remote worktree keeps the provided host.
+		{"devbox", "/home/user/src/github.com/acme/project", "devbox:5096~/.../github.com/acme/project"},
+		// Short repo path passes through unshortened.
+		{"", "/short/path", "localhost:5096/short/path"},
+	}
+	for _, tt := range tests {
+		got := formatURI(tt.host, tt.repo)
+		if got != tt.want {
+			t.Errorf("formatURI(%q, %q) = %q, want %q", tt.host, tt.repo, got, tt.want)
+		}
+	}
+}
+
+func TestFormatURICustomPort(t *testing.T) {
+	t.Setenv("WT_OPENCODE_PORT", "9999")
+	got := formatURI("", "/short/path")
+	want := "localhost:9999/short/path"
+	if got != want {
+		t.Errorf("formatURI with WT_OPENCODE_PORT=9999: got %q, want %q", got, want)
+	}
+}
+
 func TestPrintTable(t *testing.T) {
 	now := time.Now()
 	rows := []Row{
@@ -126,7 +156,7 @@ func TestPrintTable(t *testing.T) {
 
 	// Header should have the right columns.
 	header := lines[0]
-	for _, col := range []string{"WORKTREE", "STATUS", "TITLE", "ACTIVITY", "TOKENS", "REPO", "HOST", "AGE"} {
+	for _, col := range []string{"WORKTREE", "STATUS", "TITLE", "URI", "TOKENS", "ACTIVITY", "AGE"} {
 		if !strings.Contains(header, col) {
 			t.Errorf("header missing column %q: %s", col, header)
 		}


### PR DESCRIPTION
## Summary
- Merge the separate REPO and HOST table columns into a single URI column formatted as `host:port/path`
- Local worktrees display as `localhost:5096/~/.../repo`, remote as `devbox:5096/~/.../repo`
- Fixes local worktrees showing `-` for host, making local and remote entries visually symmetric

## Example
```
WORKTREE  STATUS   TITLE             URI                                         TOKENS  ACTIVITY  AGE
a3f8c12   working  Fix auth handler  localhost:5096/~/.../acme/project            42k     5m        1d
b7e2a09   working  Add metrics       devbox:5096/~/.../acme/project               8k      now       2h
```