### PR TITLE
Pull on every command for accurate status and merge detection

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -51,11 +51,11 @@ func findWorktree(name string) (worktree.Entry, bool) {
 }
 
 // discoverAll discovers worktrees and enriches them with session data.
-// Git fetch runs concurrently with enrichment; per-repo done channels are
-// returned so callers can gate classification on each repo's fetch completing.
+// Git pull runs concurrently with enrichment; per-repo done channels are
+// returned so callers can gate classification on each repo's pull completing.
 // Returns any enrichment error — callers that make safety decisions must
 // check this; callers that only display can ignore it.
-func discoverAll(remoteOnly, fetch bool) ([]worktree.Entry, fetchResult, error) {
+func discoverAll(remoteOnly, pull bool) ([]worktree.Entry, pullResult, error) {
 	host := os.Getenv("WT_REMOTE_HOST")
 
 	localCh := make(chan []worktree.Entry, 1)
@@ -79,7 +79,7 @@ func discoverAll(remoteOnly, fetch bool) ([]worktree.Entry, fetchResult, error) 
 		remoteCh <- remoteResult{}
 	}
 
-	// Discover in parallel, then fetch and enrich.
+	// Discover in parallel, then pull and enrich.
 	local := <-localCh
 	rr := <-remoteCh
 	if rr.err != nil {
@@ -96,17 +96,17 @@ func discoverAll(remoteOnly, fetch bool) ([]worktree.Entry, fetchResult, error) 
 	localEntries := all[:len(local)]
 	remoteEntries := all[len(local):]
 
-	// Run git fetch and session enrichment concurrently. Fetch is non-blocking —
+	// Run git pull and session enrichment concurrently. Pull is non-blocking —
 	// per-repo done channels are returned for callers to wait on per-entry,
-	// overlapping fetch with classification instead of serializing them.
+	// overlapping pull with classification instead of serializing them.
 	var wg sync.WaitGroup
 	var localErr, remoteErr error
 
-	var fetched fetchResult
-	if fetch {
-		fetched = startFetchRepos(all)
+	var pulled pullResult
+	if pull {
+		pulled = startPullRepos(all)
 	} else {
-		fetched = make(fetchResult)
+		pulled = make(pullResult)
 	}
 
 	if !remoteOnly {
@@ -137,7 +137,7 @@ func discoverAll(remoteOnly, fetch bool) ([]worktree.Entry, fetchResult, error) 
 
 	wg.Wait()
 
-	return all, fetched, errors.Join(localErr, remoteErr)
+	return all, pulled, errors.Join(localErr, remoteErr)
 }
 
 // hostFor returns the SSH host for an entry, or "" for local entries.
@@ -145,11 +145,11 @@ func hostFor(e worktree.Entry) string {
 	return e.Host
 }
 
-// fetchResult holds per-repo done channels from a non-blocking fetch.
-// Wait blocks until the given entry's repo has been fetched.
-type fetchResult map[repoKey]<-chan struct{}
+// pullResult holds per-repo done channels from a non-blocking pull.
+// Wait blocks until the given entry's repo has been pulled.
+type pullResult map[repoKey]<-chan struct{}
 
-func (f fetchResult) Wait(e worktree.Entry) {
+func (f pullResult) Wait(e worktree.Entry) {
 	if ch, ok := f[repoKey{hostFor(e), e.Repo}]; ok {
 		<-ch
 	}
@@ -157,12 +157,13 @@ func (f fetchResult) Wait(e worktree.Entry) {
 
 type repoKey struct{ host, repo string }
 
-// startFetchRepos kicks off git fetch for each unique repo and returns
+// startPullRepos kicks off git pull for each unique repo and returns
 // immediately. Each repo gets its own goroutine; the returned channels
-// close when each repo's fetch completes.
-func startFetchRepos(entries []worktree.Entry) fetchResult {
+// close when each repo's pull completes. Warnings are printed to stderr
+// for any repos that fail to pull.
+func startPullRepos(entries []worktree.Entry) pullResult {
 	seen := make(map[repoKey]bool)
-	result := make(fetchResult)
+	result := make(pullResult)
 	for _, e := range entries {
 		k := repoKey{hostFor(e), e.Repo}
 		if seen[k] {
@@ -172,7 +173,9 @@ func startFetchRepos(entries []worktree.Entry) fetchResult {
 		ch := make(chan struct{})
 		result[k] = ch
 		go func(k repoKey, ch chan struct{}) {
-			git.Fetch(k.host, k.repo)
+			if err := git.Pull(k.host, k.repo); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: pull failed for %s: %v\n", k.repo, err)
+			}
 			close(ch)
 		}(k, ch)
 	}

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -126,10 +126,11 @@ history, and reattaching resumes the session.
 Create or resume a worktree.
 
 - No args: pull the current branch to ensure the worktree starts from the
-  latest remote state. Create a new worktree. Attach.
+  latest remote state. Create a new worktree. Attach. Pull again on exit so
+  the exit summary reflects the latest remote state.
 - With `name`: pull the repo's default branch (best-effort) to keep it fresh
   for future worktree creation and merge detection. Resume
-  `<repo>/.worktrees/<name>`. Attach.
+  `<repo>/.worktrees/<name>`. Attach. Pull again on exit.
 
 ### `wt -r <path>`
 
@@ -138,7 +139,8 @@ Create a new remote worktree.
 - `path` identifies the repo as a local-style path
   (e.g., `~/src/acme/api`), translated to the remote
   equivalent.
-- Pulls the current branch, then creates a new worktree. Attach.
+- Pulls the current branch, then creates a new worktree. Attach. Pull again
+  on exit.
 
 ### Attach
 
@@ -177,15 +179,19 @@ touch the same files). Phase 3 computes the branch's aggregate diff patch-id
 and searches `origin/<default>` for a commit with a matching patch-id. This
 works for both single-commit and multi-commit squash merges.
 
-All read paths (ls, rm) fetch from origin to ensure remote-tracking refs are
-current. Removal deletes the worktree
+All commands pull from origin (`git pull --ff-only --prune`) to keep the
+default branch current for accurate merge detection and status classification.
+Pre-creation pulls hard-fail (stale default branch means the new worktree
+branches from the wrong place). All other pulls are best-effort — warn and
+continue. Removal deletes the worktree
 directory and the branch. Session history in the database is not touched.
 
 ### `wt diff <name>`
 
-Show the changes on a worktree's branch. Computes the merge-base with
-`origin/<default>` and diffs against it, capturing both committed and
-uncommitted changes.
+Show the changes on a worktree's branch. Pulls the repo's default branch
+(best-effort) so the diff is computed against the latest remote state. Computes
+the merge-base with `origin/<default>` and diffs against it, capturing both
+committed and uncommitted changes.
 
 Output: `--stat` summary printed directly (stays in scrollback), then the full
 diff piped through `less -R` when stdout is a terminal. When piped (e.g., to an

--- a/main.go
+++ b/main.go
@@ -79,6 +79,9 @@ func cmdLocal(args []string) {
 		if err := attach(serverURL, wtDir, ""); err != nil {
 			die("%v", err)
 		}
+		if err := git.Pull("", repo); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: pull failed: %v\n", err)
+		}
 		printExitRow(serverURL, worktree.Entry{
 			Name:      name,
 			Dir:       wtDir,
@@ -107,6 +110,9 @@ func cmdLocal(args []string) {
 		if err := attach(serverURL, entry.Dir, sessionID); err != nil {
 			die("%v", err)
 		}
+		if err := git.Pull(host, entry.Repo); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: pull failed: %v\n", err)
+		}
 		printExitRow(serverURL, entry)
 	} else {
 		if err := ssh.EnsureTunnel(entry.Host, opencode.TunnelPort(), opencode.ServerPort()); err != nil {
@@ -119,6 +125,9 @@ func cmdLocal(args []string) {
 		sessionID := opencode.FindLatestSession(remoteURL, entry.Dir)
 		if err := attach(remoteURL, entry.Dir, sessionID); err != nil {
 			die("%v", err)
+		}
+		if err := git.Pull(host, entry.Repo); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: pull failed: %v\n", err)
 		}
 		printExitRow(remoteURL, entry)
 	}
@@ -168,6 +177,9 @@ func cmdRemote(args []string) {
 	if err := attach(serverURL, wtDir, sessionID); err != nil {
 		die("%v", err)
 	}
+	if err := git.Pull(host, repo); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: pull failed: %v\n", err)
+	}
 	printExitRow(serverURL, worktree.Entry{
 		Name:      name,
 		Dir:       wtDir,
@@ -179,7 +191,7 @@ func cmdRemote(args []string) {
 
 // cmdLs handles: wt ls
 func cmdLs(remoteOnly bool) {
-	all, fetched, enrichErr := discoverAll(remoteOnly, true)
+	all, pulled, enrichErr := discoverAll(remoteOnly, true)
 	if enrichErr != nil {
 		die("%v", enrichErr)
 	}
@@ -190,7 +202,7 @@ func cmdLs(remoteOnly bool) {
 		return
 	}
 
-	statuses := classifyAll(all, fetched)
+	statuses := classifyAll(all, pulled)
 
 	rows := make([]display.Row, len(all))
 	for i, e := range all {
@@ -213,6 +225,10 @@ func cmdDiff(args []string) {
 		die("worktree %q not found", name)
 	}
 	host := hostFor(entry)
+
+	if err := git.Pull(host, entry.Repo); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: pull failed: %v\n", err)
+	}
 
 	stat, err := git.DiffStat(host, entry.Dir)
 	if err != nil {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -394,18 +394,8 @@ func IsClean(host, dir string) bool {
 	return err == nil && out == ""
 }
 
-// Fetch updates remote tracking refs for a repo.
-func Fetch(host, repo string) {
-	args := []string{"fetch", "origin"}
-	out, _ := runCapture(host, repo, args...)
-	if out != "" {
-		logCmd(host, repo, out, args...)
-	}
-}
-
-// Pull fetches with prune and fast-forwards the current branch. Used before
-// creating worktrees so they branch from the latest remote state. Uses
-// --ff-only to fail explicitly if the local branch has diverged.
+// Pull fetches with prune and fast-forwards the current branch.
+// Uses --ff-only to fail explicitly if the local branch has diverged.
 func Pull(host, repo string) error {
 	args := []string{"pull", "--ff-only", "--prune"}
 	out, err := runCapture(host, repo, args...)

--- a/rm.go
+++ b/rm.go
@@ -28,7 +28,7 @@ func cmdRm(args []string, remoteOnly bool) {
 
 // classifyAll classifies all entries, batching remote entries into a single
 // SSH call per host and classifying local entries in parallel goroutines.
-func classifyAll(all []worktree.Entry, fetched fetchResult) []string {
+func classifyAll(all []worktree.Entry, pulled pullResult) []string {
 	statuses := make([]string, len(all))
 
 	type remoteEntry struct {
@@ -47,7 +47,7 @@ func classifyAll(all []worktree.Entry, fetched fetchResult) []string {
 
 	var wg sync.WaitGroup
 
-	// Remote: wait for fetches, then one SSH call per host.
+	// Remote: wait for pulls, then one SSH call per host.
 	for host, entries := range remoteByHost {
 		wg.Add(1)
 		go func(host string, entries []remoteEntry) {
@@ -56,7 +56,7 @@ func classifyAll(all []worktree.Entry, fetched fetchResult) []string {
 			for _, re := range entries {
 				if !seen[re.entry.Repo] {
 					seen[re.entry.Repo] = true
-					fetched.Wait(re.entry)
+					pulled.Wait(re.entry)
 				}
 			}
 			var batchEntries []git.ClassifyEntry
@@ -98,7 +98,7 @@ func classifyAll(all []worktree.Entry, fetched fetchResult) []string {
 		go func(idx int, entry worktree.Entry) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			fetched.Wait(entry)
+			pulled.Wait(entry)
 			statuses[idx] = classifyStatus(entry)
 		}(i, all[i])
 	}
@@ -170,7 +170,7 @@ func isRemovable(status string) bool {
 }
 
 func cmdRmBatch(remoteOnly bool) {
-	all, fetched, enrichErr := discoverAll(remoteOnly, false)
+	all, pulled, enrichErr := discoverAll(remoteOnly, true)
 	if enrichErr != nil {
 		die("cannot determine session status: %v", enrichErr)
 	}
@@ -186,7 +186,7 @@ func cmdRmBatch(remoteOnly bool) {
 		errMsg string
 	}
 
-	statuses := classifyAll(all, fetched)
+	statuses := classifyAll(all, pulled)
 
 	// Remove sequentially
 	var results []result


### PR DESCRIPTION
## Summary
- Replace `git fetch` with `git pull --ff-only --prune` on all commands so the default branch stays current for accurate merge detection and status classification
- Add post-exit pull before `printExitRow` on `wt`, `wt <name>`, and `wt -r` so the exit summary reflects the latest remote state
- Add pre-diff pull on `wt diff` so diffs are computed against the current default branch
- Enable pull on `wt rm` (was previously disabled) so merge detection is accurate before safety decisions
- Remove dead `git.Fetch` function

All pull failures surface as warnings to stderr — never silently swallowed, never blocking.