### PR TITLE
fix: diff and classify against upstream tracking ref, not origin/main

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -126,9 +126,11 @@ history, and reattaching resumes the session.
 Create or resume a worktree.
 
 - No args: pull the current branch to ensure the worktree starts from the
-  latest remote state. Create a new worktree. Attach. Pull again on exit so
-  the exit summary reflects the latest remote state.
-- With `name`: pull the repo's default branch (best-effort) to keep it fresh
+  latest remote state. Create a new worktree with its upstream tracking ref set
+  to `origin/<root-branch>`, where root-branch is whatever the repo root has
+  checked out. Attach. Pull again on exit so the exit summary reflects the
+  latest remote state.
+- With `name`: pull the repo's current branch (best-effort) to keep it fresh
   for future worktree creation and merge detection. Resume
   `<repo>/.worktrees/<name>`. Attach. Pull again on exit.
 
@@ -170,28 +172,31 @@ state from `wt ls`.
 landed, the session went dormant with no commits, or no session was ever
 created. All other statuses are kept. `wt ls` is the preview.
 
-Merge detection is three-phase: (1) ancestry check (`merge-base --is-ancestor`)
+Merge detection uses the branch's upstream tracking ref (set at creation time)
+as the target. Three-phase: (1) ancestry check (`merge-base --is-ancestor`)
 catches regular and fast-forward merges; (2) merge-tree simulation
 (`merge-tree --write-tree`, requires git 2.38+) catches squash merges when the
 branch merges cleanly; (3) patch-id comparison catches squash merges when
-merge-tree produces conflicts (e.g., main has moved forward and later commits
-touch the same files). Phase 3 computes the branch's aggregate diff patch-id
-and searches `origin/<default>` for a commit with a matching patch-id. This
+merge-tree produces conflicts (e.g., the upstream has moved forward and later
+commits touch the same files). Phase 3 computes the branch's aggregate diff
+patch-id and searches the upstream for a commit with a matching patch-id. This
 works for both single-commit and multi-commit squash merges.
 
 All commands pull from origin (`git pull --ff-only --prune`) to keep the
-default branch current for accurate merge detection and status classification.
-Pre-creation pulls hard-fail (stale default branch means the new worktree
-branches from the wrong place). All other pulls are best-effort — warn and
-continue. Removal deletes the worktree
-directory and the branch. Session history in the database is not touched.
+current branch fresh for accurate merge detection and status classification.
+Pre-creation pulls hard-fail (stale branch means the new worktree branches from
+the wrong place). All other pulls are best-effort — warn and continue. Removal
+deletes the worktree directory and the branch. Session history in the database
+is not touched.
 
 ### `wt diff <name>`
 
-Show the changes on a worktree's branch. Pulls the repo's default branch
+Show the changes on a worktree's branch. Pulls the repo's current branch
 (best-effort) so the diff is computed against the latest remote state. Computes
-the merge-base with `origin/<default>` and diffs against it, capturing both
-committed and uncommitted changes.
+the merge-base between the branch's upstream tracking ref and HEAD, then diffs
+against it, capturing both committed and uncommitted changes. The upstream is set
+at worktree creation time to `origin/<root-branch>` — the remote-tracking ref
+for whatever branch the repo root had checked out.
 
 Output: `--stat` summary printed directly (stays in scrollback), then the full
 diff piped through `less -R` when stdout is a terminal. When piped (e.g., to an
@@ -224,7 +229,7 @@ reliable way to distinguish a long-running response from a crash orphan.
 crashed session) is preferable to a false negative (hiding active work).
 
 Git state is determined per worktree (parallel, bounded to 8 concurrent) by
-checking the working tree and branch against `origin/<default>`.
+checking the working tree and branch against its upstream tracking ref.
 
 ```
 WORKTREE            STATUS       TITLE                           REPO                              TOKENS  ACTIVITY  AGE
@@ -255,8 +260,8 @@ removed by `wt rm`.
 | `attached` | TUI client connected |
 | `working` | Agent streaming (last assistant message incomplete) |
 | `dirty` | Uncommitted changes in working tree |
-| `merged *` | Changes incorporated into `origin/<default>` |
-| `committed` | Unique commits not in `origin/<default>` |
+| `merged *` | Changes incorporated into upstream |
+| `committed` | Unique commits not in upstream |
 | `idle` | Session exists, no unique commits, recent |
 | `stale *` | Session inactive >4 hours, no unique commits |
 | `empty *` | No session was ever created |
@@ -275,8 +280,9 @@ commits. Attachment is detected by scanning local `opencode attach` processes.
 
 ## Assumptions
 
-- The repo root checkout is on the default branch and clean. Worktree creation
-  pulls this branch, so conflicts or uncommitted changes would cause a failure.
+- The repo root checkout is clean. Worktree creation pulls the current branch,
+  so conflicts or uncommitted changes would cause a failure. The checked-out
+  branch determines the upstream for new worktrees.
 - The remote host is reachable via SSH.
 - `opencode` is available on PATH (locally and on the remote host).
 

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func cmdLocal(args []string) {
 		die("worktree %q not found", name)
 	}
 
-	// Pull the repo's default branch to keep it fresh for new worktrees
+	// Pull the repo's current branch to keep it fresh for new worktrees
 	// and merge detection. Best-effort — warn and continue on failure.
 	host := hostFor(entry)
 	if err := git.Pull(host, entry.Repo); err != nil {
@@ -291,8 +291,8 @@ Status:
   attached    TUI client connected
   working     Agent generating
   dirty       Uncommitted changes in working tree
-  merged *    Changes incorporated into default branch
-  committed   Unique commits not yet in default branch
+  merged *    Changes incorporated into upstream
+  committed   Unique commits not yet in upstream
   idle        Session exists, no unique commits
   stale *     Session inactive >4 hours, no unique commits
   empty *     No session was ever created

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/ellistarn/wt/pkg/display"
 	"github.com/ellistarn/wt/pkg/ssh"
@@ -41,6 +40,8 @@ func RepoRoot(host string, dir ...string) (string, error) {
 }
 
 // WorktreeAdd creates a new worktree at <repo>/.worktrees/<name> on branch <name>.
+// Sets the new branch's upstream tracking ref to origin/<root-branch>, where
+// root-branch is whatever the repo root has checked out.
 func WorktreeAdd(host, repo, name string) error {
 	args := []string{"worktree", "add", ".worktrees/" + name, "-b", name}
 	out, err := runCapture(host, repo, args...)
@@ -48,6 +49,16 @@ func WorktreeAdd(host, repo, name string) error {
 		return err
 	}
 	logCmd(host, repo, out, args...)
+
+	// Determine the root branch (what the repo root has checked out)
+	rootBranch, err := runGit(host, repo, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return fmt.Errorf("cannot determine root branch: %w", err)
+	}
+	// Set upstream so diff/ls know what to compare against
+	if _, err := runGit(host, repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name); err != nil {
+		return fmt.Errorf("cannot set upstream for %s: %w", name, err)
+	}
 	return nil
 }
 
@@ -77,44 +88,26 @@ func runGit(host, dir string, args ...string) (string, error) {
 	return strings.TrimSpace(out), err
 }
 
-// defaultBranchCache avoids redundant git calls for the same repo.
-// Key: "host\x00repo", Value: branch name string.
-var defaultBranchCache sync.Map
-
-// DefaultBranch returns the default branch name (e.g., "main" or "master")
-// by checking refs/remotes/origin/HEAD, then probing main and master.
-// Results are cached per (host, repo) for the lifetime of the process.
-func DefaultBranch(host, repo string) string {
-	cacheKey := host + "\x00" + repo
-	if v, ok := defaultBranchCache.Load(cacheKey); ok {
-		return v.(string)
+// UpstreamRef returns the upstream tracking ref for the given branch
+// (e.g., "origin/krocodile"). Returns an error if no upstream is configured.
+// Works from any directory in the repo (worktree or root).
+func UpstreamRef(host, dir, branch string) (string, error) {
+	out, err := runGit(host, dir, "for-each-ref", "--format=%(upstream:short)", "refs/heads/"+branch)
+	if err != nil || out == "" {
+		return "", fmt.Errorf("no upstream configured for branch %q\n\nSet it with: git branch --set-upstream-to=origin/<base> %s", branch, branch)
 	}
-	result := defaultBranchUncached(host, repo)
-	defaultBranchCache.Store(cacheKey, result)
-	return result
-}
-
-func defaultBranchUncached(host, repo string) string {
-	out, err := runGit(host, repo, "symbolic-ref", "refs/remotes/origin/HEAD")
-	if err == nil {
-		// refs/remotes/origin/main -> main
-		parts := strings.Split(out, "/")
-		return parts[len(parts)-1]
-	}
-	// Probe common names
-	for _, name := range []string{"main", "master"} {
-		if _, err := runGit(host, repo, "rev-parse", "--verify", "refs/remotes/origin/"+name); err == nil {
-			return name
-		}
-	}
-	return "main" // fallback
+	return out, nil
 }
 
 // UniqueCommitCount returns the number of commits on branch that are not on
-// origin/<default>. Returns 0 if the branch has not diverged.
+// its upstream tracking ref. Returns 0 if the branch has not diverged or has
+// no upstream configured.
 func UniqueCommitCount(host, repo, branch string) int {
-	def := DefaultBranch(host, repo)
-	out, err := runGit(host, repo, "rev-list", "--count", "origin/"+def+".."+branch)
+	upstream, err := UpstreamRef(host, repo, branch)
+	if err != nil {
+		return 0
+	}
+	out, err := runGit(host, repo, "rev-list", "--count", upstream+".."+branch)
 	if err != nil {
 		return 0
 	}
@@ -123,24 +116,27 @@ func UniqueCommitCount(host, repo, branch string) int {
 }
 
 // IsMerged returns true if the branch's changes are incorporated into
-// origin/<default> (regular merge, fast-forward, or squash merge).
+// its upstream tracking ref (regular merge, fast-forward, or squash merge).
 //
 // Detection is three-phase:
 //  1. Ancestry check — catches regular merges and fast-forward merges.
 //  2. Merge-tree simulation — catches squash merges when the branch merges
-//     cleanly into origin/<default>. Requires git 2.38+.
+//     cleanly into the upstream. Requires git 2.38+.
 //  3. Patch-id comparison — catches squash merges when merge-tree produces
-//     conflicts (e.g., when origin/<default> has moved forward significantly).
+//     conflicts (e.g., when the upstream has moved forward significantly).
 //     Computes the branch's aggregate diff patch-id and searches for a commit
-//     on origin/<default> with a matching patch-id. Works for single and
+//     on the upstream with a matching patch-id. Works for single and
 //     multi-commit squash merges.
 //
 // Callers should only invoke this when the branch has unique commits
 // (UniqueCommitCount > 0). A branch with no divergence trivially matches
 // the target tree and would produce a false positive.
 func IsMerged(host, repo, branch string) bool {
-	def := DefaultBranch(host, repo)
-	target := "origin/" + def
+	upstream, err := UpstreamRef(host, repo, branch)
+	if err != nil {
+		return false
+	}
+	target := upstream
 
 	// Phase 1: ancestry check (regular merge / fast-forward).
 	if _, err := runGit(host, repo, "merge-base", "--is-ancestor", branch, target); err == nil {
@@ -240,8 +236,8 @@ type ClassifyEntry struct {
 // ClassifyResult holds the git classification for a single worktree.
 type ClassifyResult struct {
 	Clean  bool // no modified, staged, or untracked files
-	Unique int  // commits on branch not on origin/<default>
-	Merged bool // branch changes incorporated into origin/<default>
+	Unique int  // commits on branch not on its upstream
+	Merged bool // branch changes incorporated into its upstream
 }
 
 // ClassifyBatch classifies multiple remote worktrees in a single SSH call.
@@ -262,17 +258,6 @@ func ClassifyBatch(host string, entries []ClassifyEntry) ([]ClassifyResult, erro
 	script := `
 set -eu
 
-default_branch() {
-    repo="$1"
-    ref=$(git -C "$repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) && { echo "${ref##*/}"; return; }
-    git -C "$repo" rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1 && { echo main; return; }
-    git -C "$repo" rev-parse --verify refs/remotes/origin/master >/dev/null 2>&1 && { echo master; return; }
-    echo main
-}
-
-# Cache default branch per repo
-declare -A def_cache
-
 while IFS=$'\t' read -r dir repo branch; do
     [ -z "$dir" ] && continue
 
@@ -284,33 +269,34 @@ while IFS=$'\t' read -r dir repo branch; do
         clean=true
     fi
 
-    # DefaultBranch (cached per repo)
-    if [ -z "${def_cache[$repo]+x}" ]; then
-        def_cache[$repo]=$(default_branch "$repo")
+    # Get upstream tracking ref for this branch
+    upstream=$(git -C "$repo" for-each-ref --format='%(upstream:short)' "refs/heads/$branch" 2>/dev/null)
+    if [ -z "$upstream" ]; then
+        printf '%s\t%s\t%s\n' "$clean" "0" "false"
+        continue
     fi
-    def="${def_cache[$repo]}"
 
     # UniqueCommitCount
-    unique=$(git -C "$repo" rev-list --count "origin/$def..$branch" 2>/dev/null) || unique=0
+    unique=$(git -C "$repo" rev-list --count "$upstream..$branch" 2>/dev/null) || unique=0
 
     # IsMerged (only if unique > 0)
     merged=false
     if [ "$unique" -gt 0 ] 2>/dev/null; then
-        if git -C "$repo" merge-base --is-ancestor "$branch" "origin/$def" 2>/dev/null; then
+        if git -C "$repo" merge-base --is-ancestor "$branch" "$upstream" 2>/dev/null; then
             merged=true
         else
-            merge_tree=$(git -C "$repo" merge-tree --write-tree "origin/$def" "$branch" 2>/dev/null) || merge_tree=""
-            target_tree=$(git -C "$repo" rev-parse "origin/${def}^{tree}" 2>/dev/null) || target_tree=""
+            merge_tree=$(git -C "$repo" merge-tree --write-tree "$upstream" "$branch" 2>/dev/null) || merge_tree=""
+            target_tree=$(git -C "$repo" rev-parse "${upstream}^{tree}" 2>/dev/null) || target_tree=""
             if [ -n "$merge_tree" ] && [ "$merge_tree" = "$target_tree" ]; then
                 merged=true
             fi
             # Phase 3: patch-id comparison (squash merge, merge-tree had conflicts)
             if [ "$merged" = "false" ]; then
-                mb=$(git -C "$repo" merge-base "origin/$def" "$branch" 2>/dev/null) || mb=""
+                mb=$(git -C "$repo" merge-base "$upstream" "$branch" 2>/dev/null) || mb=""
                 if [ -n "$mb" ]; then
                     bpid=$(git -C "$repo" diff "$mb" "$branch" 2>/dev/null | git patch-id --stable 2>/dev/null | awk '{print $1}')
                     if [ -n "$bpid" ]; then
-                        match=$(git -C "$repo" log -p --max-count=500 "$mb..origin/$def" 2>/dev/null | git patch-id --stable 2>/dev/null | awk -v pid="$bpid" '$1 == pid {print "yes"; exit}')
+                        match=$(git -C "$repo" log -p --max-count=500 "$mb..$upstream" 2>/dev/null | git patch-id --stable 2>/dev/null | awk -v pid="$bpid" '$1 == pid {print "yes"; exit}')
                         if [ "$match" = "yes" ]; then
                             merged=true
                         fi
@@ -347,18 +333,25 @@ done << 'ENTRIES'
 }
 
 // DiffStat returns a --stat summary of changes on this branch vs the merge-base
-// with origin/<default>. Returns "" if there are no changes.
+// with its upstream tracking ref. Returns "" if there are no changes.
 func DiffStat(host, dir string) (string, error) {
-	def := DefaultBranch(host, dir)
+	branch, err := runGit(host, dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("cannot determine branch: %w", err)
+	}
+	upstream, err := UpstreamRef(host, dir, branch)
+	if err != nil {
+		return "", err
+	}
 	if host != "" {
 		script := fmt.Sprintf(
-			`mb=$(git -C '%s' merge-base 'origin/%s' HEAD) && git -C '%s' diff --stat "$mb"`,
-			dir, def, dir,
+			`mb=$(git -C '%s' merge-base '%s' HEAD) && git -C '%s' diff --stat "$mb"`,
+			dir, upstream, dir,
 		)
 		out, err := ssh.Run(host, script)
 		return strings.TrimSpace(out), err
 	}
-	mb, err := runGit("", dir, "merge-base", "origin/"+def, "HEAD")
+	mb, err := runGit("", dir, "merge-base", upstream, "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("merge-base: %w", err)
 	}
@@ -366,22 +359,29 @@ func DiffStat(host, dir string) (string, error) {
 }
 
 // Diff returns the full diff of changes on this branch vs the merge-base
-// with origin/<default>. If color is true, ANSI color codes are included.
+// with its upstream tracking ref. If color is true, ANSI color codes are included.
 func Diff(host, dir string, color bool) (string, error) {
-	def := DefaultBranch(host, dir)
+	branch, err := runGit(host, dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("cannot determine branch: %w", err)
+	}
+	upstream, err := UpstreamRef(host, dir, branch)
+	if err != nil {
+		return "", err
+	}
 	colorFlag := "--color=never"
 	if color {
 		colorFlag = "--color=always"
 	}
 	if host != "" {
 		script := fmt.Sprintf(
-			`mb=$(git -C '%s' merge-base 'origin/%s' HEAD) && git -C '%s' diff '%s' "$mb"`,
-			dir, def, dir, colorFlag,
+			`mb=$(git -C '%s' merge-base '%s' HEAD) && git -C '%s' diff '%s' "$mb"`,
+			dir, upstream, dir, colorFlag,
 		)
 		out, err := ssh.Run(host, script)
 		return strings.TrimSpace(out), err
 	}
-	mb, err := runGit("", dir, "merge-base", "origin/"+def, "HEAD")
+	mb, err := runGit("", dir, "merge-base", upstream, "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("merge-base: %w", err)
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -91,6 +91,9 @@ func (e *testEnv) addWorktree(name string) string {
 	e.t.Helper()
 	wtDir := filepath.Join(e.repo, ".worktrees", name)
 	gitCmd(e.t, e.repo, "worktree", "add", wtDir, "-b", name)
+	// Set upstream tracking to match WorktreeAdd behavior.
+	rootBranch := strings.TrimSpace(gitCmd(e.t, e.repo, "rev-parse", "--abbrev-ref", "HEAD"))
+	gitCmd(e.t, e.repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name)
 	return wtDir
 }
 
@@ -673,4 +676,75 @@ func TestDiff_NotFound(t *testing.T) {
 	t.Log("output:\n" + out)
 
 	assertContains(t, out, "not found")
+}
+
+// TestDiff_NonDefaultBranch verifies that wt diff uses the upstream tracking
+// ref, not the repo's default branch. Reproduces the bug where a worktree
+// branched from a non-default branch (e.g., krocodile) would diff against
+// origin/main instead of origin/<actual-base>.
+func TestDiff_NonDefaultBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	// Create a non-default branch "krocodile" with its own commits
+	gitCmd(t, env.repo, "checkout", "-b", "krocodile")
+	env.commitFile(env.repo, "kroc.txt", "krocodile content", "krocodile base")
+	gitCmd(t, env.repo, "push", "origin", "krocodile")
+
+	// Now create a worktree from krocodile (repo root is on krocodile)
+	wt := env.addWorktree("feature-on-kroc")
+	env.commitFile(wt, "feature.txt", "new feature", "add feature on krocodile")
+
+	out := env.wt("diff", "feature-on-kroc")
+	t.Log("output:\n" + out)
+
+	// Should show feature.txt (the worktree's change) but NOT kroc.txt
+	// (which is on krocodile, the base branch)
+	assertContains(t, out, "feature.txt")
+	if strings.Contains(out, "kroc.txt") {
+		t.Error("diff should be against origin/krocodile (upstream), not origin/main; kroc.txt should not appear")
+	}
+}
+
+// TestLs_NonDefaultBranch verifies that wt ls correctly classifies worktrees
+// branched from a non-default branch using the upstream tracking ref.
+func TestLs_NonDefaultBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	// Create a non-default branch "krocodile" with its own commits
+	gitCmd(t, env.repo, "checkout", "-b", "krocodile")
+	env.commitFile(env.repo, "kroc.txt", "krocodile content", "krocodile base")
+	gitCmd(t, env.repo, "push", "origin", "krocodile")
+
+	// Create a worktree from krocodile, commit, push, and merge back
+	wt := env.addWorktree("kroc-merged")
+	env.commitFile(wt, "f.txt", "done", "feature")
+	gitCmd(t, env.repo, "push", "origin", "kroc-merged")
+	// Merge into krocodile (not main)
+	gitCmd(t, env.repo, "checkout", "krocodile")
+	gitCmd(t, env.repo, "merge", "--no-ff", "kroc-merged", "-m", "merge kroc-merged")
+	gitCmd(t, env.repo, "push", "origin", "krocodile")
+	gitCmd(t, env.repo, "fetch", "origin")
+
+	env.createIdleSession(wt)
+
+	out := env.wt("ls")
+	t.Log("output:\n" + out)
+
+	// Should be classified as merged (not committed) since it's merged into krocodile
+	if !strings.Contains(out, "kroc-merged") {
+		t.Error("worktree should appear in ls output")
+	}
+	// The branch is merged into origin/krocodile (its upstream), so it should
+	// be classified as "empty" (ancestor check: unique=0 after merge, since
+	// all commits are reachable from origin/krocodile).
+	// With the old DefaultBranch code, it would show as "committed" because
+	// origin/main doesn't contain the krocodile commits.
 }

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -59,7 +59,11 @@ func newSSHTestEnv(t *testing.T) *sshTestEnv {
 func (e *sshTestEnv) addWorktree(name string) string {
 	e.t.Helper()
 	wtDir := e.repo + "/.worktrees/" + name
-	sshRun(e.t, e.host, fmt.Sprintf("cd %s && git worktree add .worktrees/%s -b %s", e.repo, name, name))
+	sshRun(e.t, e.host, fmt.Sprintf(
+		"cd %s && git worktree add .worktrees/%s -b %s && "+
+			"root=$(git rev-parse --abbrev-ref HEAD) && "+
+			"git branch --set-upstream-to=origin/$root %s",
+		e.repo, name, name, name))
 	return wtDir
 }
 


### PR DESCRIPTION
## Summary

- `wt diff` and `wt ls` classification compared against `origin/main` (the repo default branch), which is wrong for repos where work happens on a different branch (e.g., `origin/krocodile` in kro). `wt diff 0423T1503-39237` showed 53K lines / 200 commits instead of the actual 0 unique commits.
- `WorktreeAdd` now sets each branch's upstream tracking ref to `origin/<root-branch>` at creation time. All callers (`DiffStat`, `Diff`, `UniqueCommitCount`, `IsMerged`, `ClassifyBatch`) query the branch's upstream instead of the global default.
- `DefaultBranch` and its cache are deleted. Tests added for non-default-branch scenarios.