### PR TITLE
Extract cmdlog package and split git into files by concept

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func cmdLs(remoteOnly bool) {
 			Status: statuses[i],
 		}
 	}
-	display.PrintTable(rows)
+	display.PrintTable(rows, opencode.ServerPort())
 }
 
 // cmdDiff handles: wt diff <name>
@@ -319,7 +319,7 @@ func printExitRow(serverURL string, entry worktree.Entry) {
 	display.PrintTable([]display.Row{{
 		Entry:  entry,
 		Status: classifyStatus(entry),
-	}})
+	}}, opencode.ServerPort())
 }
 
 // attach runs opencode attach as a subprocess, connecting to the given server.

--- a/pkg/cmdlog/cmdlog.go
+++ b/pkg/cmdlog/cmdlog.go
@@ -1,4 +1,4 @@
-package display
+package cmdlog
 
 import (
 	"fmt"

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -3,11 +3,11 @@ package display
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
 
+	"github.com/ellistarn/wt/pkg/cmdlog"
 	"github.com/ellistarn/wt/pkg/worktree"
 )
 
@@ -26,11 +26,12 @@ var removableStatuses = map[string]bool{
 }
 
 // PrintTable prints rows as an aligned table. Removable statuses get a * suffix.
-func PrintTable(rows []Row) {
+// serverPort is the OpenCode server port used to render the URI column.
+func PrintTable(rows []Row, serverPort int) {
 	if len(rows) == 0 {
 		return
 	}
-	if HasLogged() {
+	if cmdlog.HasLogged() {
 		fmt.Println()
 	}
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
@@ -49,7 +50,7 @@ func PrintTable(rows []Row) {
 		if title == "" {
 			title = "-"
 		}
-		uri := formatURI(e.Host, e.Repo)
+		uri := formatURI(e.Host, e.Repo, serverPort)
 		age := formatDuration(e.CreatedAt, now)
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, uri, tokens, activity, age)
 	}
@@ -119,7 +120,7 @@ func formatRepo(repo string) string {
 }
 
 // formatURI combines host and repo into a single host:port/path string.
-func formatURI(host, repo string) string {
+func formatURI(host, repo string, port int) string {
 	if host == "" {
 		host = "localhost"
 	}
@@ -127,18 +128,7 @@ func formatURI(host, repo string) string {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	return fmt.Sprintf("%s:%d%s", host, serverPort(), path)
-}
-
-// serverPort returns the OpenCode server port (default 5096, overridden by WT_OPENCODE_PORT).
-// This duplicates opencode.ServerPort() to avoid an import cycle (opencode → display).
-func serverPort() int {
-	if s := os.Getenv("WT_OPENCODE_PORT"); s != "" {
-		if p, err := strconv.Atoi(s); err == nil {
-			return p
-		}
-	}
-	return 5096
+	return fmt.Sprintf("%s:%d%s", host, port, path)
 }
 
 func FormatAge(t time.Time, now time.Time) string {
@@ -161,4 +151,3 @@ func FormatAge(t time.Time, now time.Time) string {
 		return fmt.Sprintf("%dd ago", days)
 	}
 }
-

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -89,19 +89,18 @@ func TestFormatURI(t *testing.T) {
 		{"", "/short/path", "localhost:5096/short/path"},
 	}
 	for _, tt := range tests {
-		got := formatURI(tt.host, tt.repo)
+		got := formatURI(tt.host, tt.repo, 5096)
 		if got != tt.want {
-			t.Errorf("formatURI(%q, %q) = %q, want %q", tt.host, tt.repo, got, tt.want)
+			t.Errorf("formatURI(%q, %q, 5096) = %q, want %q", tt.host, tt.repo, got, tt.want)
 		}
 	}
 }
 
 func TestFormatURICustomPort(t *testing.T) {
-	t.Setenv("WT_OPENCODE_PORT", "9999")
-	got := formatURI("", "/short/path")
+	got := formatURI("", "/short/path", 9999)
 	want := "localhost:9999/short/path"
 	if got != want {
-		t.Errorf("formatURI with WT_OPENCODE_PORT=9999: got %q, want %q", got, want)
+		t.Errorf("formatURI with port 9999: got %q, want %q", got, want)
 	}
 }
 
@@ -140,7 +139,7 @@ func TestPrintTable(t *testing.T) {
 	old := os.Stdout
 	os.Stdout = w
 
-	PrintTable(rows)
+	PrintTable(rows, 5096)
 
 	w.Close()
 	os.Stdout = old

--- a/pkg/git/classify.go
+++ b/pkg/git/classify.go
@@ -1,0 +1,250 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/ellistarn/wt/pkg/ssh"
+)
+
+// IsClean returns true if the worktree has no modified, staged, or untracked files.
+func IsClean(host, dir string) bool {
+	out, err := runGit(host, dir, "status", "--porcelain")
+	return err == nil && out == ""
+}
+
+// UniqueCommitCount returns the number of commits on branch that are not on
+// its upstream tracking ref. Returns 0 if the branch has not diverged or has
+// no upstream configured.
+func UniqueCommitCount(host, repo, branch string) int {
+	upstream, err := UpstreamRef(host, repo, branch)
+	if err != nil {
+		return 0
+	}
+	out, err := runGit(host, repo, "rev-list", "--count", upstream+".."+branch)
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(out)
+	return n
+}
+
+// IsMerged returns true if the branch's changes are incorporated into
+// its upstream tracking ref (regular merge, fast-forward, or squash merge).
+//
+// Detection is three-phase:
+//  1. Ancestry check — catches regular merges and fast-forward merges.
+//  2. Merge-tree simulation — catches squash merges when the branch merges
+//     cleanly into the upstream. Requires git 2.38+.
+//  3. Patch-id comparison — catches squash merges when merge-tree produces
+//     conflicts (e.g., when the upstream has moved forward significantly).
+//     Computes the branch's aggregate diff patch-id and searches for a commit
+//     on the upstream with a matching patch-id. Works for single and
+//     multi-commit squash merges.
+//
+// Callers should only invoke this when the branch has unique commits
+// (UniqueCommitCount > 0). A branch with no divergence trivially matches
+// the target tree and would produce a false positive.
+func IsMerged(host, repo, branch string) bool {
+	upstream, err := UpstreamRef(host, repo, branch)
+	if err != nil {
+		return false
+	}
+	target := upstream
+
+	// Phase 1: ancestry check (regular merge / fast-forward).
+	if _, err := runGit(host, repo, "merge-base", "--is-ancestor", branch, target); err == nil {
+		return true
+	}
+
+	// Phase 2: merge-tree simulation (squash merge, no conflicts).
+	mergeTree, err := runGit(host, repo, "merge-tree", "--write-tree", target, branch)
+	if err == nil {
+		targetTree, err := runGit(host, repo, "rev-parse", target+"^{tree}")
+		if err == nil && mergeTree == targetTree {
+			return true
+		}
+	}
+
+	// Phase 3: patch-id comparison (squash merge, merge-tree had conflicts).
+	return hasPatchIDMatch(host, repo, target, branch)
+}
+
+// hasPatchIDMatch computes the aggregate patch-id of the branch's diff
+// (merge-base to branch tip) and checks whether any commit on the target
+// has the same patch-id. This detects squash merges even when merge-tree
+// simulation fails due to conflicts with later changes on the target.
+// Works for both single-commit and multi-commit squash merges.
+func hasPatchIDMatch(host, repo, target, branch string) bool {
+	mergeBase, err := runGit(host, repo, "merge-base", target, branch)
+	if err != nil {
+		return false
+	}
+	diff, err := runGit(host, repo, "diff", mergeBase, branch)
+	if err != nil || diff == "" {
+		return false
+	}
+	branchPID := computePatchID(diff)
+	if branchPID == "" {
+		return false
+	}
+	return searchPatchID(repo, mergeBase+".."+target, branchPID)
+}
+
+// computePatchID computes the patch-id of a diff by piping it through
+// git patch-id --stable.
+func computePatchID(diff string) string {
+	cmd := exec.Command("git", "patch-id", "--stable")
+	cmd.Stdin = strings.NewReader(diff)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	if fields := strings.Fields(strings.TrimSpace(string(out))); len(fields) > 0 {
+		return fields[0]
+	}
+	return ""
+}
+
+// searchPatchID pipes git log -p through git patch-id --stable and checks
+// whether any commit in the range has the given patch-id. Searches at most
+// 500 commits to bound cost on repos with long histories.
+func searchPatchID(repo, revRange, targetPID string) bool {
+	logCmd := exec.Command("git", "-C", repo, "log", "-p", "--max-count=500", revRange)
+	pidCmd := exec.Command("git", "patch-id", "--stable")
+
+	pipe, err := logCmd.StdoutPipe()
+	if err != nil {
+		return false
+	}
+	pidCmd.Stdin = pipe
+
+	var out bytes.Buffer
+	pidCmd.Stdout = &out
+
+	if err := logCmd.Start(); err != nil {
+		return false
+	}
+	if err := pidCmd.Start(); err != nil {
+		logCmd.Process.Kill()
+		return false
+	}
+	logCmd.Wait()
+	pidCmd.Wait()
+
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if fields := strings.Fields(line); len(fields) > 0 && fields[0] == targetPID {
+			return true
+		}
+	}
+	return false
+}
+
+// ClassifyEntry holds the input for batch classification.
+type ClassifyEntry struct {
+	Dir    string // worktree directory
+	Repo   string // repo root
+	Branch string // branch name
+}
+
+// ClassifyResult holds the git classification for a single worktree.
+type ClassifyResult struct {
+	Clean  bool // no modified, staged, or untracked files
+	Unique int  // commits on branch not on its upstream
+	Merged bool // branch changes incorporated into its upstream
+}
+
+// ClassifyBatch classifies multiple remote worktrees in a single SSH call.
+// Replicates the logic of IsClean + UniqueCommitCount + IsMerged but runs
+// all git commands on the remote host in one round-trip.
+// Returns an error if the SSH call fails entirely.
+func ClassifyBatch(host string, entries []ClassifyEntry) ([]ClassifyResult, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Build heredoc with one entry per line: dir\trepo\tbranch
+	var heredoc strings.Builder
+	for _, e := range entries {
+		fmt.Fprintf(&heredoc, "%s\t%s\t%s\n", e.Dir, e.Repo, e.Branch)
+	}
+
+	script := `
+set -eu
+
+while IFS=$'\t' read -r dir repo branch; do
+    [ -z "$dir" ] && continue
+
+    # IsClean
+    status=$(git -C "$dir" status --porcelain 2>/dev/null) || status=""
+    if [ -n "$status" ]; then
+        clean=false
+    else
+        clean=true
+    fi
+
+    # Get upstream tracking ref for this branch
+    upstream=$(git -C "$repo" for-each-ref --format='%(upstream:short)' "refs/heads/$branch" 2>/dev/null)
+    if [ -z "$upstream" ]; then
+        printf '%s\t%s\t%s\n' "$clean" "0" "false"
+        continue
+    fi
+
+    # UniqueCommitCount
+    unique=$(git -C "$repo" rev-list --count "$upstream..$branch" 2>/dev/null) || unique=0
+
+    # IsMerged (only if unique > 0)
+    merged=false
+    if [ "$unique" -gt 0 ] 2>/dev/null; then
+        if git -C "$repo" merge-base --is-ancestor "$branch" "$upstream" 2>/dev/null; then
+            merged=true
+        else
+            merge_tree=$(git -C "$repo" merge-tree --write-tree "$upstream" "$branch" 2>/dev/null) || merge_tree=""
+            target_tree=$(git -C "$repo" rev-parse "${upstream}^{tree}" 2>/dev/null) || target_tree=""
+            if [ -n "$merge_tree" ] && [ "$merge_tree" = "$target_tree" ]; then
+                merged=true
+            fi
+            # Phase 3: patch-id comparison (squash merge, merge-tree had conflicts)
+            if [ "$merged" = "false" ]; then
+                mb=$(git -C "$repo" merge-base "$upstream" "$branch" 2>/dev/null) || mb=""
+                if [ -n "$mb" ]; then
+                    bpid=$(git -C "$repo" diff "$mb" "$branch" 2>/dev/null | git patch-id --stable 2>/dev/null | awk '{print $1}')
+                    if [ -n "$bpid" ]; then
+                        match=$(git -C "$repo" log -p --max-count=500 "$mb..$upstream" 2>/dev/null | git patch-id --stable 2>/dev/null | awk -v pid="$bpid" '$1 == pid {print "yes"; exit}')
+                        if [ "$match" = "yes" ]; then
+                            merged=true
+                        fi
+                    fi
+                fi
+            fi
+        fi
+    fi
+
+    printf '%s\t%s\t%s\n' "$clean" "$unique" "$merged"
+done << 'ENTRIES'
+` + heredoc.String() + `ENTRIES
+`
+	out, err := ssh.Run(host, script)
+	if err != nil {
+		return nil, fmt.Errorf("remote classify: %w", err)
+	}
+
+	results := make([]ClassifyResult, len(entries))
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for i, line := range lines {
+		if i >= len(entries) {
+			break
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) < 3 {
+			continue
+		}
+		results[i].Clean = parts[0] == "true"
+		results[i].Unique, _ = strconv.Atoi(parts[1])
+		results[i].Merged = parts[2] == "true"
+	}
+	return results, nil
+}

--- a/pkg/git/diff.go
+++ b/pkg/git/diff.go
@@ -1,0 +1,64 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ellistarn/wt/pkg/ssh"
+)
+
+// DiffStat returns a --stat summary of changes on this branch vs the merge-base
+// with its upstream tracking ref. Returns "" if there are no changes.
+func DiffStat(host, dir string) (string, error) {
+	branch, err := runGit(host, dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("cannot determine branch: %w", err)
+	}
+	upstream, err := UpstreamRef(host, dir, branch)
+	if err != nil {
+		return "", err
+	}
+	if host != "" {
+		script := fmt.Sprintf(
+			`mb=$(git -C '%s' merge-base '%s' HEAD) && git -C '%s' diff --stat "$mb"`,
+			dir, upstream, dir,
+		)
+		out, err := ssh.Run(host, script)
+		return strings.TrimSpace(out), err
+	}
+	mb, err := runGit("", dir, "merge-base", upstream, "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("merge-base: %w", err)
+	}
+	return runGit("", dir, "diff", "--stat", mb)
+}
+
+// Diff returns the full diff of changes on this branch vs the merge-base
+// with its upstream tracking ref. If color is true, ANSI color codes are included.
+func Diff(host, dir string, color bool) (string, error) {
+	branch, err := runGit(host, dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("cannot determine branch: %w", err)
+	}
+	upstream, err := UpstreamRef(host, dir, branch)
+	if err != nil {
+		return "", err
+	}
+	colorFlag := "--color=never"
+	if color {
+		colorFlag = "--color=always"
+	}
+	if host != "" {
+		script := fmt.Sprintf(
+			`mb=$(git -C '%s' merge-base '%s' HEAD) && git -C '%s' diff '%s' "$mb"`,
+			dir, upstream, dir, colorFlag,
+		)
+		out, err := ssh.Run(host, script)
+		return strings.TrimSpace(out), err
+	}
+	mb, err := runGit("", dir, "merge-base", upstream, "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("merge-base: %w", err)
+	}
+	return runGit("", dir, "diff", colorFlag, mb)
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,15 +1,13 @@
 package git
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
-	"github.com/ellistarn/wt/pkg/display"
+	"github.com/ellistarn/wt/pkg/cmdlog"
 	"github.com/ellistarn/wt/pkg/ssh"
 )
 
@@ -39,29 +37,6 @@ func RepoRoot(host string, dir ...string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
-// WorktreeAdd creates a new worktree at <repo>/.worktrees/<name> on branch <name>.
-// Sets the new branch's upstream tracking ref to origin/<root-branch>, where
-// root-branch is whatever the repo root has checked out.
-func WorktreeAdd(host, repo, name string) error {
-	args := []string{"worktree", "add", ".worktrees/" + name, "-b", name}
-	out, err := runCapture(host, repo, args...)
-	if err != nil {
-		return err
-	}
-	logCmd(host, repo, out, args...)
-
-	// Determine the root branch (what the repo root has checked out)
-	rootBranch, err := runGit(host, repo, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		return fmt.Errorf("cannot determine root branch: %w", err)
-	}
-	// Set upstream so diff/ls know what to compare against
-	if _, err := runGit(host, repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name); err != nil {
-		return fmt.Errorf("cannot set upstream for %s: %w", name, err)
-	}
-	return nil
-}
-
 // DirExists checks whether a directory exists, locally or over SSH.
 func DirExists(host, path string) bool {
 	if host == "" {
@@ -70,6 +45,17 @@ func DirExists(host, path string) bool {
 	}
 	_, err := ssh.Run(host, fmt.Sprintf("test -d '%s'", path))
 	return err == nil
+}
+
+// UpstreamRef returns the upstream tracking ref for the given branch
+// (e.g., "origin/krocodile"). Returns an error if no upstream is configured.
+// Works from any directory in the repo (worktree or root).
+func UpstreamRef(host, dir, branch string) (string, error) {
+	out, err := runGit(host, dir, "for-each-ref", "--format=%(upstream:short)", "refs/heads/"+branch)
+	if err != nil || out == "" {
+		return "", fmt.Errorf("no upstream configured for branch %q\n\nSet it with: git branch --set-upstream-to=origin/<base> %s", branch, branch)
+	}
+	return out, nil
 }
 
 // runGit runs a git command in the given directory. If host is empty, runs locally.
@@ -86,355 +72,6 @@ func runGit(host, dir string, args ...string) (string, error) {
 	script := fmt.Sprintf("git -C '%s' %s", dir, strings.Join(quoted, " "))
 	out, err := ssh.Run(host, script)
 	return strings.TrimSpace(out), err
-}
-
-// UpstreamRef returns the upstream tracking ref for the given branch
-// (e.g., "origin/krocodile"). Returns an error if no upstream is configured.
-// Works from any directory in the repo (worktree or root).
-func UpstreamRef(host, dir, branch string) (string, error) {
-	out, err := runGit(host, dir, "for-each-ref", "--format=%(upstream:short)", "refs/heads/"+branch)
-	if err != nil || out == "" {
-		return "", fmt.Errorf("no upstream configured for branch %q\n\nSet it with: git branch --set-upstream-to=origin/<base> %s", branch, branch)
-	}
-	return out, nil
-}
-
-// UniqueCommitCount returns the number of commits on branch that are not on
-// its upstream tracking ref. Returns 0 if the branch has not diverged or has
-// no upstream configured.
-func UniqueCommitCount(host, repo, branch string) int {
-	upstream, err := UpstreamRef(host, repo, branch)
-	if err != nil {
-		return 0
-	}
-	out, err := runGit(host, repo, "rev-list", "--count", upstream+".."+branch)
-	if err != nil {
-		return 0
-	}
-	n, _ := strconv.Atoi(out)
-	return n
-}
-
-// IsMerged returns true if the branch's changes are incorporated into
-// its upstream tracking ref (regular merge, fast-forward, or squash merge).
-//
-// Detection is three-phase:
-//  1. Ancestry check — catches regular merges and fast-forward merges.
-//  2. Merge-tree simulation — catches squash merges when the branch merges
-//     cleanly into the upstream. Requires git 2.38+.
-//  3. Patch-id comparison — catches squash merges when merge-tree produces
-//     conflicts (e.g., when the upstream has moved forward significantly).
-//     Computes the branch's aggregate diff patch-id and searches for a commit
-//     on the upstream with a matching patch-id. Works for single and
-//     multi-commit squash merges.
-//
-// Callers should only invoke this when the branch has unique commits
-// (UniqueCommitCount > 0). A branch with no divergence trivially matches
-// the target tree and would produce a false positive.
-func IsMerged(host, repo, branch string) bool {
-	upstream, err := UpstreamRef(host, repo, branch)
-	if err != nil {
-		return false
-	}
-	target := upstream
-
-	// Phase 1: ancestry check (regular merge / fast-forward).
-	if _, err := runGit(host, repo, "merge-base", "--is-ancestor", branch, target); err == nil {
-		return true
-	}
-
-	// Phase 2: merge-tree simulation (squash merge, no conflicts).
-	mergeTree, err := runGit(host, repo, "merge-tree", "--write-tree", target, branch)
-	if err == nil {
-		targetTree, err := runGit(host, repo, "rev-parse", target+"^{tree}")
-		if err == nil && mergeTree == targetTree {
-			return true
-		}
-	}
-
-	// Phase 3: patch-id comparison (squash merge, merge-tree had conflicts).
-	return hasPatchIDMatch(host, repo, target, branch)
-}
-
-// hasPatchIDMatch computes the aggregate patch-id of the branch's diff
-// (merge-base to branch tip) and checks whether any commit on the target
-// has the same patch-id. This detects squash merges even when merge-tree
-// simulation fails due to conflicts with later changes on the target.
-// Works for both single-commit and multi-commit squash merges.
-func hasPatchIDMatch(host, repo, target, branch string) bool {
-	mergeBase, err := runGit(host, repo, "merge-base", target, branch)
-	if err != nil {
-		return false
-	}
-	diff, err := runGit(host, repo, "diff", mergeBase, branch)
-	if err != nil || diff == "" {
-		return false
-	}
-	branchPID := computePatchID(diff)
-	if branchPID == "" {
-		return false
-	}
-	return searchPatchID(repo, mergeBase+".."+target, branchPID)
-}
-
-// computePatchID computes the patch-id of a diff by piping it through
-// git patch-id --stable.
-func computePatchID(diff string) string {
-	cmd := exec.Command("git", "patch-id", "--stable")
-	cmd.Stdin = strings.NewReader(diff)
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	if fields := strings.Fields(strings.TrimSpace(string(out))); len(fields) > 0 {
-		return fields[0]
-	}
-	return ""
-}
-
-// searchPatchID pipes git log -p through git patch-id --stable and checks
-// whether any commit in the range has the given patch-id. Searches at most
-// 500 commits to bound cost on repos with long histories.
-func searchPatchID(repo, revRange, targetPID string) bool {
-	logCmd := exec.Command("git", "-C", repo, "log", "-p", "--max-count=500", revRange)
-	pidCmd := exec.Command("git", "patch-id", "--stable")
-
-	pipe, err := logCmd.StdoutPipe()
-	if err != nil {
-		return false
-	}
-	pidCmd.Stdin = pipe
-
-	var out bytes.Buffer
-	pidCmd.Stdout = &out
-
-	if err := logCmd.Start(); err != nil {
-		return false
-	}
-	if err := pidCmd.Start(); err != nil {
-		logCmd.Process.Kill()
-		return false
-	}
-	logCmd.Wait()
-	pidCmd.Wait()
-
-	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		if fields := strings.Fields(line); len(fields) > 0 && fields[0] == targetPID {
-			return true
-		}
-	}
-	return false
-}
-
-// ClassifyEntry holds the input for batch classification.
-type ClassifyEntry struct {
-	Dir    string // worktree directory
-	Repo   string // repo root
-	Branch string // branch name
-}
-
-// ClassifyResult holds the git classification for a single worktree.
-type ClassifyResult struct {
-	Clean  bool // no modified, staged, or untracked files
-	Unique int  // commits on branch not on its upstream
-	Merged bool // branch changes incorporated into its upstream
-}
-
-// ClassifyBatch classifies multiple remote worktrees in a single SSH call.
-// Replicates the logic of IsClean + UniqueCommitCount + IsMerged but runs
-// all git commands on the remote host in one round-trip.
-// Returns an error if the SSH call fails entirely.
-func ClassifyBatch(host string, entries []ClassifyEntry) ([]ClassifyResult, error) {
-	if len(entries) == 0 {
-		return nil, nil
-	}
-
-	// Build heredoc with one entry per line: dir\trepo\tbranch
-	var heredoc strings.Builder
-	for _, e := range entries {
-		fmt.Fprintf(&heredoc, "%s\t%s\t%s\n", e.Dir, e.Repo, e.Branch)
-	}
-
-	script := `
-set -eu
-
-while IFS=$'\t' read -r dir repo branch; do
-    [ -z "$dir" ] && continue
-
-    # IsClean
-    status=$(git -C "$dir" status --porcelain 2>/dev/null) || status=""
-    if [ -n "$status" ]; then
-        clean=false
-    else
-        clean=true
-    fi
-
-    # Get upstream tracking ref for this branch
-    upstream=$(git -C "$repo" for-each-ref --format='%(upstream:short)' "refs/heads/$branch" 2>/dev/null)
-    if [ -z "$upstream" ]; then
-        printf '%s\t%s\t%s\n' "$clean" "0" "false"
-        continue
-    fi
-
-    # UniqueCommitCount
-    unique=$(git -C "$repo" rev-list --count "$upstream..$branch" 2>/dev/null) || unique=0
-
-    # IsMerged (only if unique > 0)
-    merged=false
-    if [ "$unique" -gt 0 ] 2>/dev/null; then
-        if git -C "$repo" merge-base --is-ancestor "$branch" "$upstream" 2>/dev/null; then
-            merged=true
-        else
-            merge_tree=$(git -C "$repo" merge-tree --write-tree "$upstream" "$branch" 2>/dev/null) || merge_tree=""
-            target_tree=$(git -C "$repo" rev-parse "${upstream}^{tree}" 2>/dev/null) || target_tree=""
-            if [ -n "$merge_tree" ] && [ "$merge_tree" = "$target_tree" ]; then
-                merged=true
-            fi
-            # Phase 3: patch-id comparison (squash merge, merge-tree had conflicts)
-            if [ "$merged" = "false" ]; then
-                mb=$(git -C "$repo" merge-base "$upstream" "$branch" 2>/dev/null) || mb=""
-                if [ -n "$mb" ]; then
-                    bpid=$(git -C "$repo" diff "$mb" "$branch" 2>/dev/null | git patch-id --stable 2>/dev/null | awk '{print $1}')
-                    if [ -n "$bpid" ]; then
-                        match=$(git -C "$repo" log -p --max-count=500 "$mb..$upstream" 2>/dev/null | git patch-id --stable 2>/dev/null | awk -v pid="$bpid" '$1 == pid {print "yes"; exit}')
-                        if [ "$match" = "yes" ]; then
-                            merged=true
-                        fi
-                    fi
-                fi
-            fi
-        fi
-    fi
-
-    printf '%s\t%s\t%s\n' "$clean" "$unique" "$merged"
-done << 'ENTRIES'
-` + heredoc.String() + `ENTRIES
-`
-	out, err := ssh.Run(host, script)
-	if err != nil {
-		return nil, fmt.Errorf("remote classify: %w", err)
-	}
-
-	results := make([]ClassifyResult, len(entries))
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	for i, line := range lines {
-		if i >= len(entries) {
-			break
-		}
-		parts := strings.SplitN(line, "\t", 3)
-		if len(parts) < 3 {
-			continue
-		}
-		results[i].Clean = parts[0] == "true"
-		results[i].Unique, _ = strconv.Atoi(parts[1])
-		results[i].Merged = parts[2] == "true"
-	}
-	return results, nil
-}
-
-// DiffStat returns a --stat summary of changes on this branch vs the merge-base
-// with its upstream tracking ref. Returns "" if there are no changes.
-func DiffStat(host, dir string) (string, error) {
-	branch, err := runGit(host, dir, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		return "", fmt.Errorf("cannot determine branch: %w", err)
-	}
-	upstream, err := UpstreamRef(host, dir, branch)
-	if err != nil {
-		return "", err
-	}
-	if host != "" {
-		script := fmt.Sprintf(
-			`mb=$(git -C '%s' merge-base '%s' HEAD) && git -C '%s' diff --stat "$mb"`,
-			dir, upstream, dir,
-		)
-		out, err := ssh.Run(host, script)
-		return strings.TrimSpace(out), err
-	}
-	mb, err := runGit("", dir, "merge-base", upstream, "HEAD")
-	if err != nil {
-		return "", fmt.Errorf("merge-base: %w", err)
-	}
-	return runGit("", dir, "diff", "--stat", mb)
-}
-
-// Diff returns the full diff of changes on this branch vs the merge-base
-// with its upstream tracking ref. If color is true, ANSI color codes are included.
-func Diff(host, dir string, color bool) (string, error) {
-	branch, err := runGit(host, dir, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		return "", fmt.Errorf("cannot determine branch: %w", err)
-	}
-	upstream, err := UpstreamRef(host, dir, branch)
-	if err != nil {
-		return "", err
-	}
-	colorFlag := "--color=never"
-	if color {
-		colorFlag = "--color=always"
-	}
-	if host != "" {
-		script := fmt.Sprintf(
-			`mb=$(git -C '%s' merge-base '%s' HEAD) && git -C '%s' diff '%s' "$mb"`,
-			dir, upstream, dir, colorFlag,
-		)
-		out, err := ssh.Run(host, script)
-		return strings.TrimSpace(out), err
-	}
-	mb, err := runGit("", dir, "merge-base", upstream, "HEAD")
-	if err != nil {
-		return "", fmt.Errorf("merge-base: %w", err)
-	}
-	return runGit("", dir, "diff", colorFlag, mb)
-}
-
-// IsClean returns true if the worktree has no modified, staged, or untracked files.
-func IsClean(host, dir string) bool {
-	out, err := runGit(host, dir, "status", "--porcelain")
-	return err == nil && out == ""
-}
-
-// Pull fetches with prune and fast-forwards the current branch.
-// Uses --ff-only to fail explicitly if the local branch has diverged.
-func Pull(host, repo string) error {
-	args := []string{"pull", "--ff-only", "--prune"}
-	out, err := runCapture(host, repo, args...)
-	if err != nil {
-		return err
-	}
-	logCmd(host, repo, out, args...)
-	return nil
-}
-
-// WorktreeRemove removes the worktree directory and deletes the branch.
-// git worktree remove deletes the directory; git branch -d deletes the branch
-// (only if merged, safe delete).
-func WorktreeRemove(host, repo, name string) error {
-	wtPath := repo + "/.worktrees/" + name
-	args := []string{"worktree", "remove", wtPath}
-	out, err := runCapture(host, repo, args...)
-	if err != nil {
-		return fmt.Errorf("git worktree remove: %w", err)
-	}
-	logCmd(host, repo, out, args...)
-	// Best-effort branch delete. -d is safe (refuses unmerged branches).
-	// If it fails (branch doesn't exist, not merged), that's fine.
-	runGit(host, repo, "branch", "-d", name)
-	return nil
-}
-
-// WorktreeForceRemove removes the worktree and branch without safety checks.
-func WorktreeForceRemove(host, repo, name string) error {
-	wtPath := repo + "/.worktrees/" + name
-	args := []string{"worktree", "remove", "--force", wtPath}
-	out, err := runCapture(host, repo, args...)
-	if err != nil {
-		return fmt.Errorf("git worktree remove --force: %w", err)
-	}
-	logCmd(host, repo, out, args...)
-	// Force delete the branch regardless of merge status.
-	runGit(host, repo, "branch", "-D", name)
-	return nil
 }
 
 // runCapture runs a git command capturing combined stdout+stderr.
@@ -458,6 +95,6 @@ func logCmd(host, dir, output string, args ...string) {
 	if host != "" {
 		cmd = host + ": " + cmd
 	}
-	display.LogCmd(cmd)
-	display.LogOutput(output)
+	cmdlog.LogCmd(cmd)
+	cmdlog.LogOutput(output)
 }

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -1,0 +1,69 @@
+package git
+
+import "fmt"
+
+// WorktreeAdd creates a new worktree at <repo>/.worktrees/<name> on branch <name>.
+// Sets the new branch's upstream tracking ref to origin/<root-branch>, where
+// root-branch is whatever the repo root has checked out.
+func WorktreeAdd(host, repo, name string) error {
+	args := []string{"worktree", "add", ".worktrees/" + name, "-b", name}
+	out, err := runCapture(host, repo, args...)
+	if err != nil {
+		return err
+	}
+	logCmd(host, repo, out, args...)
+
+	// Determine the root branch (what the repo root has checked out)
+	rootBranch, err := runGit(host, repo, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return fmt.Errorf("cannot determine root branch: %w", err)
+	}
+	// Set upstream so diff/ls know what to compare against
+	if _, err := runGit(host, repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name); err != nil {
+		return fmt.Errorf("cannot set upstream for %s: %w", name, err)
+	}
+	return nil
+}
+
+// Pull fetches with prune and fast-forwards the current branch.
+// Uses --ff-only to fail explicitly if the local branch has diverged.
+func Pull(host, repo string) error {
+	args := []string{"pull", "--ff-only", "--prune"}
+	out, err := runCapture(host, repo, args...)
+	if err != nil {
+		return err
+	}
+	logCmd(host, repo, out, args...)
+	return nil
+}
+
+// WorktreeRemove removes the worktree directory and deletes the branch.
+// git worktree remove deletes the directory; git branch -d deletes the branch
+// (only if merged, safe delete).
+func WorktreeRemove(host, repo, name string) error {
+	wtPath := repo + "/.worktrees/" + name
+	args := []string{"worktree", "remove", wtPath}
+	out, err := runCapture(host, repo, args...)
+	if err != nil {
+		return fmt.Errorf("git worktree remove: %w", err)
+	}
+	logCmd(host, repo, out, args...)
+	// Best-effort branch delete. -d is safe (refuses unmerged branches).
+	// If it fails (branch doesn't exist, not merged), that's fine.
+	runGit(host, repo, "branch", "-d", name)
+	return nil
+}
+
+// WorktreeForceRemove removes the worktree and branch without safety checks.
+func WorktreeForceRemove(host, repo, name string) error {
+	wtPath := repo + "/.worktrees/" + name
+	args := []string{"worktree", "remove", "--force", wtPath}
+	out, err := runCapture(host, repo, args...)
+	if err != nil {
+		return fmt.Errorf("git worktree remove --force: %w", err)
+	}
+	logCmd(host, repo, out, args...)
+	// Force delete the branch regardless of merge status.
+	runGit(host, repo, "branch", "-D", name)
+	return nil
+}

--- a/pkg/opencode/server.go
+++ b/pkg/opencode/server.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ellistarn/wt/pkg/display"
+	"github.com/ellistarn/wt/pkg/cmdlog"
 	"github.com/ellistarn/wt/pkg/ssh"
 )
 
@@ -44,7 +44,7 @@ func EnsureLocalServer() error {
 	}
 
 	cmd := exec.Command(binary, "serve", "--port", strconv.Itoa(port))
-	display.LogCmd(fmt.Sprintf("opencode serve --port %d", port))
+	cmdlog.LogCmd(fmt.Sprintf("opencode serve --port %d", port))
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 	if err == nil {
@@ -84,7 +84,7 @@ func EnsureRemoteServer(host string) error {
 
 	port := ServerPort()
 	startCmd := fmt.Sprintf("$SHELL -ic 'nohup opencode serve --port %d </dev/null >/dev/null 2>&1 &'", port)
-	display.LogCmd(fmt.Sprintf("%s: opencode serve --port %d", host, port))
+	cmdlog.LogCmd(fmt.Sprintf("%s: opencode serve --port %d", host, port))
 	if _, err := ssh.Run(host, startCmd); err != nil {
 		// Race — someone else may have started it.
 		if healthProbe(tunnelURL) == nil {

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ellistarn/wt/pkg/display"
+	"github.com/ellistarn/wt/pkg/cmdlog"
 )
 
 // Host returns WT_REMOTE_HOST or an error if unset.
@@ -90,7 +90,7 @@ func EnsureTunnel(host string, localPort, remotePort int) error {
 		"-o", "ControlMaster=yes",
 		"-o", "ControlPath="+controlPath,
 		"-fNL", fmt.Sprintf("%d:localhost:%d", localPort, remotePort), host)
-	display.LogCmd(fmt.Sprintf("ssh -fNL %d:localhost:%d %s", localPort, remotePort, host))
+	cmdlog.LogCmd(fmt.Sprintf("ssh -fNL %d:localhost:%d %s", localPort, remotePort, host))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Another process may have started the tunnel between our health
 		// check and this SSH invocation (race on "address already in use").

--- a/rm.go
+++ b/rm.go
@@ -232,7 +232,7 @@ func cmdRmBatch(remoteOnly bool) {
 			Status: r.status,
 		}
 	}
-	display.PrintTable(rows)
+	display.PrintTable(rows, opencode.ServerPort())
 
 	for _, r := range results {
 		if r.errMsg != "" {
@@ -258,5 +258,5 @@ func cmdRmTargeted(name string) {
 	display.PrintTable([]display.Row{{
 		Entry:  entry,
 		Status: "removed",
-	}})
+	}}, opencode.ServerPort())
 }


### PR DESCRIPTION
## Summary

- Extract command logging (`LogCmd`, `LogOutput`, `HasLogged`) from `display` into new `cmdlog` package, eliminating the `serverPort()` duplication caused by the `opencode → display` import cycle.
- Split `git/git.go` (463 lines, 4 concepts) into `git.go`, `classify.go`, `diff.go`, `worktree.go` so file names reflect the architecture.
- `PrintTable` now takes `serverPort int` as a parameter instead of reading the env var internally — pure function of its inputs.

## Import graph after

```
main ─┬─ worktree      (leaf)
      ├─ cmdlog        (new leaf — command trace logging)
      ├─ display  → worktree, cmdlog  (rendering only, consumed only by main)
      ├─ ssh      → cmdlog
      ├─ git      → ssh, cmdlog
      ├─ discover → worktree, ssh
      └─ opencode → worktree, ssh, cmdlog
```

No logic, algorithm, or behavior changes. Code moves only.