### PR TITLE
Fix merge detection for rebase/fast-forward merges

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -22,6 +22,12 @@ A **worktree** is a git worktree at `<repo>/.worktrees/<name>`, where `name`
 equals the branch name. The worktree directory is the primary key. Worktrees are
 created per unit of work and cleaned up separately when the branch lands.
 
+The **root branch** is whatever branch the repo root has checked out at worktree
+creation time (typically `main`). Each worktree records `origin/<root-branch>` as
+its merge target. Diff, status, and merge detection all compare the worktree's
+branch against this target. The value is set once at creation and does not change
+if the repo root later checks out a different branch.
+
 A **session** is an OpenCode conversation bound to a worktree directory. Sessions
 persist on the server and carry a title (auto-generated from the first prompt)
 and full message history. A worktree can have multiple sessions; the most recent
@@ -126,9 +132,8 @@ history, and reattaching resumes the session.
 Create or resume a worktree.
 
 - No args: pull the current branch to ensure the worktree starts from the
-  latest remote state. Create a new worktree with its upstream tracking ref set
-  to `origin/<root-branch>`, where root-branch is whatever the repo root has
-  checked out. Attach. Pull again on exit so the exit summary reflects the
+  latest remote state. Create a new worktree with `origin/<root-branch>` as its
+  merge target. Attach. Pull again on exit so the exit summary reflects the
   latest remote state.
 - With `name`: pull the repo's current branch (best-effort) to keep it fresh
   for future worktree creation and merge detection. Resume
@@ -172,15 +177,29 @@ state from `wt ls`.
 landed, the session went dormant with no commits, or no session was ever
 created. All other statuses are kept. `wt ls` is the preview.
 
-Merge detection uses the branch's upstream tracking ref (set at creation time)
-as the target. Three-phase: (1) ancestry check (`merge-base --is-ancestor`)
-catches regular and fast-forward merges; (2) merge-tree simulation
-(`merge-tree --write-tree`, requires git 2.38+) catches squash merges when the
-branch merges cleanly; (3) patch-id comparison catches squash merges when
-merge-tree produces conflicts (e.g., the upstream has moved forward and later
-commits touch the same files). Phase 3 computes the branch's aggregate diff
-patch-id and searches the upstream for a commit with a matching patch-id. This
-works for both single-commit and multi-commit squash merges.
+Merge detection compares the worktree's branch against `origin/<root-branch>`.
+Detection splits into two paths based on whether the branch has commits not
+reachable from the target (`git rev-list --count target..branch`).
+
+When the branch has **unique commits** (count > 0), three phases run in order:
+(1) ancestry check (`merge-base --is-ancestor`) — the branch tip is a graph
+ancestor of the target, meaning a merge commit incorporated it; (2) merge-tree
+simulation (`merge-tree --write-tree`, requires git 2.38+) — simulating the
+merge produces the same tree as the target, meaning the branch's diff is already
+present (catches squash merges and GitHub rebase merges, which create new SHAs);
+(3) patch-id comparison — the branch's aggregate diff has the same patch-id as a
+commit on the target (catches squash merges when merge-tree produces conflicts
+because the target moved forward). Phase 3 scans at most 500 commits on the
+target range to bound cost.
+
+When the branch has **zero unique commits** (count = 0), the branch's commits
+are already reachable from the target — either because a merge commit made them
+ancestors, or because the target adopted them with identical SHAs (fast-forward).
+In this case the three-phase check is not applicable (there is nothing unique to
+match against). Instead, a behind-target check fires: if the branch tip is a
+proper ancestor of the target (behind, not at the same commit) and the worktree
+has a session, it is classified as merged. A branch at exactly the target tip has
+not diverged and is classified by session lifecycle (idle, stale, or empty).
 
 All commands pull from origin (`git pull --ff-only --prune`) to keep the
 current branch fresh for accurate merge detection and status classification.
@@ -193,10 +212,8 @@ is not touched.
 
 Show the changes on a worktree's branch. Pulls the repo's current branch
 (best-effort) so the diff is computed against the latest remote state. Computes
-the merge-base between the branch's upstream tracking ref and HEAD, then diffs
-against it, capturing both committed and uncommitted changes. The upstream is set
-at worktree creation time to `origin/<root-branch>` — the remote-tracking ref
-for whatever branch the repo root had checked out.
+the merge-base between `origin/<root-branch>` and HEAD, then diffs against it,
+capturing both committed and uncommitted changes.
 
 Output: `--stat` summary printed directly (stays in scrollback), then the full
 diff piped through `less -R` when stdout is a terminal. When piped (e.g., to an
@@ -229,7 +246,7 @@ reliable way to distinguish a long-running response from a crash orphan.
 crashed session) is preferable to a false negative (hiding active work).
 
 Git state is determined per worktree (parallel, bounded to 8 concurrent) by
-checking the working tree and branch against its upstream tracking ref.
+checking the working tree and branch against `origin/<root-branch>`.
 
 ```
 WORKTREE            STATUS       TITLE                           REPO                              TOKENS  ACTIVITY  AGE
@@ -260,17 +277,23 @@ removed by `wt rm`.
 | `attached` | TUI client connected |
 | `working` | Agent streaming (last assistant message incomplete) |
 | `dirty` | Uncommitted changes in working tree |
-| `merged *` | Changes incorporated into upstream |
-| `committed` | Unique commits not in upstream |
-| `idle` | Session exists, no unique commits, recent |
-| `stale *` | Session inactive >4 hours, no unique commits |
+| `merged *` | Changes incorporated into `origin/<root-branch>` |
+| `committed` | Unique commits not yet in `origin/<root-branch>` |
 | `empty *` | No session was ever created |
+| `stale *` | Session inactive >4 hours, no unique commits |
+| `idle` | Session exists, no unique commits, recent |
 
 Session states (`attached`, `working`) take priority — the worktree is in active
 use. Git states (`dirty`, `merged`, `committed`) take priority next — they
-describe the safety of the work. Session lifecycle states (`idle`, `stale`,
-`empty`) apply when the working tree is clean and the branch has no unique
-commits. Attachment is detected by scanning local `opencode attach` processes.
+describe the safety of the work. `merged` covers both detection paths: unique
+commits detected as landed (three-phase), and zero unique commits with the branch
+behind the target (behind-target check). Session lifecycle states (`empty`,
+`stale`, `idle`) apply when the working tree is clean and the branch has no
+unique commits. A worktree with no session is `empty` regardless of the branch's
+position relative to the target — it never had work to merge. A worktree with a
+session whose branch is behind the target is `merged` — the work landed via a
+merge that made the branch's commits reachable from the target. Attachment is
+detected by scanning local `opencode attach` processes.
 
 ## Reconnection
 
@@ -282,7 +305,7 @@ commits. Attachment is detected by scanning local `opencode attach` processes.
 
 - The repo root checkout is clean. Worktree creation pulls the current branch,
   so conflicts or uncommitted changes would cause a failure. The checked-out
-  branch determines the upstream for new worktrees.
+  branch becomes the root branch for the new worktree.
 - The remote host is reachable via SSH.
 - `opencode` is available on PATH (locally and on the remote host).
 

--- a/pkg/git/classify.go
+++ b/pkg/git/classify.go
@@ -32,6 +32,33 @@ func UniqueCommitCount(host, repo, branch string) int {
 	return n
 }
 
+// IsBehindUpstream returns true if the branch tip is a proper ancestor of
+// its upstream — i.e., the branch is strictly behind (not at the same commit).
+// This detects merges where the branch's commits became reachable from
+// upstream: regular merge commits (--no-ff), fast-forward merges, and local
+// rebases where the upstream adopted the branch's commits with identical SHAs.
+// In all these cases, rev-list sees zero unique commits because the branch
+// has not diverged from the upstream's ancestry graph.
+func IsBehindUpstream(host, repo, branch string) bool {
+	upstream, err := UpstreamRef(host, repo, branch)
+	if err != nil {
+		return false
+	}
+	branchRev, err := runGit(host, repo, "rev-parse", "refs/heads/"+branch)
+	if err != nil {
+		return false
+	}
+	upstreamRev, err := runGit(host, repo, "rev-parse", upstream)
+	if err != nil {
+		return false
+	}
+	if branchRev == upstreamRev {
+		return false // at upstream tip, not behind
+	}
+	_, err = runGit(host, repo, "merge-base", "--is-ancestor", branch, upstream)
+	return err == nil
+}
+
 // IsMerged returns true if the branch's changes are incorporated into
 // its upstream tracking ref (regular merge, fast-forward, or squash merge).
 //
@@ -155,6 +182,7 @@ type ClassifyResult struct {
 	Clean  bool // no modified, staged, or untracked files
 	Unique int  // commits on branch not on its upstream
 	Merged bool // branch changes incorporated into its upstream
+	Behind bool // branch is a proper ancestor of its upstream (rebase merge)
 }
 
 // ClassifyBatch classifies multiple remote worktrees in a single SSH call.
@@ -189,7 +217,7 @@ while IFS=$'\t' read -r dir repo branch; do
     # Get upstream tracking ref for this branch
     upstream=$(git -C "$repo" for-each-ref --format='%(upstream:short)' "refs/heads/$branch" 2>/dev/null)
     if [ -z "$upstream" ]; then
-        printf '%s\t%s\t%s\n' "$clean" "0" "false"
+        printf '%s\t%s\t%s\t%s\n' "$clean" "0" "false" "false"
         continue
     fi
 
@@ -223,7 +251,19 @@ while IFS=$'\t' read -r dir repo branch; do
         fi
     fi
 
-    printf '%s\t%s\t%s\n' "$clean" "$unique" "$merged"
+    # IsBehindUpstream (only if unique == 0): detect rebase/ff merges
+    behind=false
+    if [ "$unique" -eq 0 ] 2>/dev/null; then
+        branch_rev=$(git -C "$repo" rev-parse "refs/heads/$branch" 2>/dev/null) || branch_rev=""
+        upstream_rev=$(git -C "$repo" rev-parse "$upstream" 2>/dev/null) || upstream_rev=""
+        if [ -n "$branch_rev" ] && [ -n "$upstream_rev" ] && [ "$branch_rev" != "$upstream_rev" ]; then
+            if git -C "$repo" merge-base --is-ancestor "$branch" "$upstream" 2>/dev/null; then
+                behind=true
+            fi
+        fi
+    fi
+
+    printf '%s\t%s\t%s\t%s\n' "$clean" "$unique" "$merged" "$behind"
 done << 'ENTRIES'
 ` + heredoc.String() + `ENTRIES
 `
@@ -238,13 +278,16 @@ done << 'ENTRIES'
 		if i >= len(entries) {
 			break
 		}
-		parts := strings.SplitN(line, "\t", 3)
+		parts := strings.SplitN(line, "\t", 4)
 		if len(parts) < 3 {
 			continue
 		}
 		results[i].Clean = parts[0] == "true"
 		results[i].Unique, _ = strconv.Atoi(parts[1])
 		results[i].Merged = parts[2] == "true"
+		if len(parts) >= 4 {
+			results[i].Behind = parts[3] == "true"
+		}
 	}
 	return results, nil
 }

--- a/rm.go
+++ b/rm.go
@@ -85,7 +85,7 @@ func classifyAll(all []worktree.Entry, pulled pullResult) []string {
 			}
 			for j, r := range results {
 				idx := batchIdxs[j]
-				statuses[idx] = classifyFromResult(all[idx], r.Clean, r.Unique, r.Merged)
+				statuses[idx] = classifyFromResult(all[idx], r.Clean, r.Unique, r.Merged, r.Behind)
 			}
 		}(host, entries)
 	}
@@ -108,7 +108,7 @@ func classifyAll(all []worktree.Entry, pulled pullResult) []string {
 }
 
 // classifyStatus returns the single highest-priority status for a worktree.
-// Priority: attached > working > dirty > merged > committed > idle > stale > empty.
+// Priority: attached > working > dirty > merged/committed > empty > merged(behind) > stale > idle.
 func classifyStatus(e worktree.Entry) string {
 	// Session states — active use takes priority
 	if e.Attached {
@@ -135,6 +135,18 @@ func classifyStatus(e worktree.Entry) string {
 	if e.SessionID == "" {
 		return "empty"
 	}
+
+	// Merged with zero unique commits: the branch's commits are reachable
+	// from upstream (regular merge commit, fast-forward, or local rebase).
+	// rev-list sees zero unique commits because the branch hasn't diverged
+	// from upstream's ancestry graph. Detect by checking if the branch is
+	// a proper ancestor of upstream (behind, not at the same commit).
+	// Only checked when a session exists — a worktree with no session
+	// never had work to merge.
+	if git.IsBehindUpstream(host, e.Repo, e.Name) {
+		return "merged"
+	}
+
 	if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
 		return "stale"
 	}
@@ -145,7 +157,7 @@ func classifyStatus(e worktree.Entry) string {
 // (from a batch SSH call) instead of making individual git calls.
 // Unlike classifyStatus, this does NOT check Attached or working status —
 // callers must handle those cases before calling this function.
-func classifyFromResult(e worktree.Entry, clean bool, unique int, merged bool) string {
+func classifyFromResult(e worktree.Entry, clean bool, unique int, merged bool, behind bool) string {
 	if !clean {
 		return "dirty"
 	}
@@ -157,6 +169,9 @@ func classifyFromResult(e worktree.Entry, clean bool, unique int, merged bool) s
 	}
 	if e.SessionID == "" {
 		return "empty"
+	}
+	if behind {
+		return "merged"
 	}
 	if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
 		return "stale"

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -523,6 +523,78 @@ func TestLs_RegressionMultiCommitSquash(t *testing.T) {
 	}
 }
 
+// TestLs_RegressionRebaseMerge verifies that merges producing zero unique
+// commits are detected. When a branch is rebased onto main (identical SHAs
+// adopted) or merged via --no-ff (commits become ancestors of the merge
+// commit), rev-list sees zero unique commits. The behind-upstream check
+// detects this: the branch tip is a proper ancestor of upstream. Requires
+// a session — a worktree with no session is classified as empty, not merged.
+func TestLs_RegressionRebaseMerge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	// Create a branch with a commit
+	wt := env.addWorktree("rebase-merged")
+	env.commitFile(wt, "r.txt", "rebase content", "rebase work")
+	env.push("rebase-merged")
+	env.createIdleSession(wt)
+
+	// Simulate rebase merge: fast-forward main to include the branch's commit
+	gitCmd(t, env.repo, "checkout", "main")
+	gitCmd(t, env.repo, "rebase", "rebase-merged")
+	gitCmd(t, env.repo, "push", "origin", "main")
+	gitCmd(t, env.repo, "fetch", "origin")
+
+	// After rebase merge, advance main further so the branch is behind
+	env.commitFile(env.repo, "extra.txt", "more main work", "main advance")
+	gitCmd(t, env.repo, "push", "origin", "main")
+	gitCmd(t, env.repo, "fetch", "origin")
+
+	out := env.wt("ls")
+	t.Log("output:\n" + out)
+
+	if !strings.Contains(out, "rebase-merged") || !strings.Contains(out, "merged *") {
+		t.Error("rebase-merged worktree should be classified as merged *")
+	}
+}
+
+// TestLs_RegressionRegularMergeWithSession verifies that a regular merge
+// commit (--no-ff) with a session is detected as merged. After the merge,
+// the branch's commits are ancestors of the merge commit on main, so
+// rev-list sees zero unique commits. The behind-upstream check fires because
+// the branch is behind upstream and has a session.
+func TestLs_RegressionRegularMergeWithSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wt := env.addWorktree("regular-merged")
+	env.commitFile(wt, "r.txt", "regular content", "regular work")
+	env.push("regular-merged")
+	env.createIdleSession(wt)
+
+	// Regular merge commit to main
+	env.mergeToMain("regular-merged")
+	gitCmd(t, env.repo, "checkout", "main")
+
+	// Advance main so the branch is behind
+	env.commitFile(env.repo, "extra.txt", "main work", "main advance")
+	gitCmd(t, env.repo, "push", "origin", "main")
+	gitCmd(t, env.repo, "fetch", "origin")
+
+	out := env.wt("ls")
+	t.Log("output:\n" + out)
+
+	if !strings.Contains(out, "regular-merged") || !strings.Contains(out, "merged *") {
+		t.Error("regular-merged worktree with session should be classified as merged *")
+	}
+}
+
 func TestLs_SessionActiveStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")


### PR DESCRIPTION
## Summary

- Rebase merges produce `UniqueCommitCount == 0` because upstream adopts the branch's commits with identical SHAs — the `IsMerged` gate (`unique > 0`) is never reached, so the branch falls through to idle/stale instead of merged.
- Adds `IsBehindUpstream`: when `unique == 0` and the branch is a proper ancestor of upstream (behind, not at the same commit), classify as "merged." Branches at exactly the upstream tip are fresh (just created), not merged.
- Applied to both the local classification path (`classifyStatus`) and the remote batch SSH path (`ClassifyBatch`).