### PR TITLE
Improve README with install, lifecycle, full command reference, and status legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ $ wt ls
 WORKTREE  STATUS     TITLE                                URI                                     TOKENS  ACTIVITY  AGE
 a3f8c12   attached   Rewrite Linux scheduler in Rust      localhost:5096/~/.../torvalds/linux     380k    now       3h
 b7e2a09   working    Implement quantum-safe cryptography  dev-desktop:5096/~/.../satoshi/bitcoin  240k    now       3d
-e1d4b83   committed  Autonomous drone delivery            localhost:5096/~/.../bezos/prime-air    85k     2h        12y
 4a0e9d6   dirty      Fix race in block allocator          localhost:5096/~/.../torvalds/linux     92k     5m        1d
+f2c7d91   idle       Write worktree session manager       localhost:5096/~/.../ellistarn/wt       150k    5m        4d
+e1d4b83   committed  Autonomous drone delivery            localhost:5096/~/.../bezos/prime-air    85k     2h        12y
 c9a1f57   merged *   Add exceptions to Go                 localhost:5096/~/.../robpike/go         45k     6h        1d
 d5b8e24   idle       Actually open OpenAI                 dev-desktop:5096/~/.../altman/openai    120k    10y       10y
 7f3b1c8   stale *    Ship Half-Life 3                     localhost:5096/~/.../gaben/hl3          30k     18y       18y
-f2c7d91   idle       Write worktree session manager       localhost:5096/~/.../ellistarn/wt       150k    5m        4d
 ```
 
 Statuses, highest priority wins:

--- a/README.md
+++ b/README.md
@@ -1,26 +1,74 @@
 # wt
 
-Worktree session manager for [OpenCode](https://opencode.ai).
+Worktree session manager for [OpenCode](https://opencode.ai). When multiple AI
+agents work on the same repo, they need isolation — separate files, separate
+branches, separate git state. `wt` gives each agent its own git worktree on its
+own branch, bound to a persistent OpenCode session, and manages the full
+lifecycle: create, list, attach, diff, clean up. Works locally and remotely via
+SSH.
 
 ```
 $ wt ls
-WORKTREE            TITLE                              STATUS    ACTIVITY  TOKENS  REPO                                    AGE
-a3f8c12     Rewrite Linux scheduler in Rust     attached  now       380k    /home/torvalds/.../linux/kernel          3h
-b7e2a09     Implement quantum-safe cryptography working   now       240k    [remote] /home/satoshi/.../bitcoin/src   3d
-e1d4b83     Autonomous drone delivery           working   now       85k     /home/bezos/.../amazon/prime-air         12y
-c9a1f57     Add exceptions to Go                idle      6h        45k     /home/robpike/.../golang/go              1d
-d5b8e24     Actually open OpenAI                idle      10y       120k    /home/altman/.../openai/models           10y
-f2c7d91     -                                   -         -         -       /home/user/.../acme/toolkit             1d
+WORKTREE       TITLE                                STATUS       ACTIVITY  TOKENS  REPO                                      AGE
+a3f8c12  Rewrite Linux scheduler in Rust      attached     now       380k    /home/torvalds/.../linux/kernel            3h
+b7e2a09  Implement quantum-safe cryptography  working      now       240k    [remote] /home/satoshi/.../bitcoin/src     3d
+e1d4b83  Autonomous drone delivery            committed    2h        85k     /home/bezos/.../amazon/prime-air           12y
+4a0e9d6  Fix race in block allocator          dirty        5m        92k     /home/torvalds/.../linux/mm                1d
+c9a1f57  Add exceptions to Go                 merged *     6h        45k     /home/robpike/.../golang/go                1d
+d5b8e24  Actually open OpenAI                 idle         10y       120k    /home/altman/.../openai/models             10y
+7f3b1c8  Refactor tokenizer                   stale *      2d        30k     [remote] /home/karpathy/.../llm.c          5d
+f2c7d91  -                                    empty *      -         -       /home/user/.../acme/toolkit                1d
+                                              # attached  — TUI client connected
+                                              # working   — agent generating
+                                              # dirty     — uncommitted changes in working tree
+                                              # merged *  — changes incorporated into upstream
+                                              # committed — unique commits not yet in upstream
+                                              # idle      — session exists, no unique commits
+                                              # stale *   — session inactive >4h, no unique commits
+                                              # empty *   — no session was ever created
 ```
 
-## Usage
+## Install
 
 ```
-wt                     # Create a new local worktree and attach
-wt <name>              # Attach to an existing worktree (local or remote)
-wt ls                  # List all worktrees
-wt -r <path>           # Create a new remote worktree and attach
+go install github.com/ellistarn/wt@latest
 ```
+
+Requires Go 1.24+, Git 2.38+, and `opencode` on PATH.
+
+## Worktree lifecycle
+
+Each worktree branches from whatever the repo root has checked out (typically
+main), with `origin/<root-branch>` as its merge target. `wt` pulls the repo
+before creating a worktree and again after you exit, so worktrees start from the
+latest remote state and merge detection stays accurate against a fresh upstream.
+
+## Commands
+
+```
+wt                        Create a new local worktree and attach
+wt <name>                 Attach to an existing worktree (local or remote)
+wt -r <path>              Create a new remote worktree and attach
+wt ls                     List all worktrees (local and remote)
+wt -r ls                  List remote worktrees only
+wt diff <name>            Show changes on a worktree's branch
+wt rm                     Remove worktrees marked * in wt ls
+wt rm <name>              Remove a specific worktree
+
+Flags:
+  -r, --remote              Operate on the remote dev desktop
+  -h, --help                Show this help
+```
+
+## Cleanup
+
+`wt rm` batch-removes worktrees whose status is marked `*`: merged (work
+landed), stale (inactive session, no commits), and empty (no session created).
+`wt ls` is the preview — what you see is what gets removed. `wt rm <name>`
+removes unconditionally.
+
+Merge detection compares against `origin/<root-branch>` and handles regular
+merges, squash merges, and rebase merges.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ e1d4b83  Autonomous drone delivery            committed    2h        85k     /ho
 4a0e9d6  Fix race in block allocator          dirty        5m        92k     /home/torvalds/.../linux/mm                1d
 c9a1f57  Add exceptions to Go                 merged *     6h        45k     /home/robpike/.../golang/go                1d
 d5b8e24  Actually open OpenAI                 idle         10y       120k    /home/altman/.../openai/models             10y
-7f3b1c8  Finish TAOCP volume 5                stale *      2d        30k     /home/knuth/.../taocp/vol5                50y
+7f3b1c8  Ship Half-Life 3                     stale *      2d        30k     /home/gaben/.../valve/hl3                 18y
 f2c7d91  Write worktree session manager       idle         5m        150k    /home/ellistarn/.../ellistarn/wt           4d
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ $ wt ls
 WORKTREE  STATUS     TITLE                                URI                                     TOKENS  ACTIVITY  AGE
 a3f8c12   attached   Rewrite Linux scheduler in Rust      localhost:5096/~/.../torvalds/linux     380k    now       3h
 b7e2a09   working    Implement quantum-safe cryptography  dev-desktop:5096/~/.../satoshi/bitcoin  240k    now       3d
-e1d4b83   committed  Autonomous drone delivery            localhost:5096/~/.../bezos/prime-air    85k     2h        12d
+e1d4b83   committed  Autonomous drone delivery            localhost:5096/~/.../bezos/prime-air    85k     2h        12y
 4a0e9d6   dirty      Fix race in block allocator          localhost:5096/~/.../torvalds/linux     92k     5m        1d
 c9a1f57   merged *   Add exceptions to Go                 localhost:5096/~/.../robpike/go         45k     6h        1d
-d5b8e24   idle       Actually open OpenAI                 dev-desktop:5096/~/.../altman/openai    120k    3h        10d
-7f3b1c8   stale *    Ship Half-Life 3                     localhost:5096/~/.../gaben/hl3          30k     2d        5d
+d5b8e24   idle       Actually open OpenAI                 dev-desktop:5096/~/.../altman/openai    120k    10y       10y
+7f3b1c8   stale *    Ship Half-Life 3                     localhost:5096/~/.../gaben/hl3          30k     18y       18y
 f2c7d91   idle       Write worktree session manager       localhost:5096/~/.../ellistarn/wt       150k    5m        4d
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ SSH.
 
 ```
 $ wt ls
-WORKTREE       TITLE                                STATUS       ACTIVITY  TOKENS  REPO                                      AGE
-a3f8c12  Rewrite Linux scheduler in Rust      attached     now       380k    /home/torvalds/.../linux/kernel            3h
-b7e2a09  Implement quantum-safe cryptography  working      now       240k    [remote] /home/satoshi/.../bitcoin/src     3d
-e1d4b83  Autonomous drone delivery            committed    2h        85k     /home/bezos/.../amazon/prime-air           12y
-4a0e9d6  Fix race in block allocator          dirty        5m        92k     /home/torvalds/.../linux/mm                1d
-c9a1f57  Add exceptions to Go                 merged *     6h        45k     /home/robpike/.../golang/go                1d
-d5b8e24  Actually open OpenAI                 idle         10y       120k    /home/altman/.../openai/models             10y
-7f3b1c8  Ship Half-Life 3                     stale *      2d        30k     /home/gaben/.../valve/hl3                 18y
-f2c7d91  Write worktree session manager       idle         5m        150k    /home/ellistarn/.../ellistarn/wt           4d
+WORKTREE       STATUS       TITLE                                URI                                           TOKENS  ACTIVITY  AGE
+a3f8c12  attached     Rewrite Linux scheduler in Rust      localhost:5096/~/.../linux/kernel            380k    now       3h
+b7e2a09  working      Implement quantum-safe cryptography  dev-desktop:5096/~/.../bitcoin/src          240k    now       3d
+e1d4b83  committed    Autonomous drone delivery            localhost:5096/~/.../amazon/prime-air       85k     2h        12d
+4a0e9d6  dirty        Fix race in block allocator          localhost:5096/~/.../linux/mm               92k     5m        1d
+c9a1f57  merged *     Add exceptions to Go                 localhost:5096/~/.../golang/go              45k     6h        1d
+d5b8e24  idle         Actually open OpenAI                 dev-desktop:5096/~/.../openai/models        120k    3h        10d
+7f3b1c8  stale *      Ship Half-Life 3                     localhost:5096/~/.../valve/hl3              30k     2d        5d
+f2c7d91  idle         Write worktree session manager       localhost:5096/~/.../ellistarn/wt           150k    5m        4d
 ```
 
 Statuses, highest priority wins:

--- a/README.md
+++ b/README.md
@@ -63,5 +63,3 @@ Flags:
   -h, --help                Show this help
 ```
 
-`wt ls` is the preview for `wt rm`. Merge detection handles regular merges,
-squash merges, and rebase merges against `origin/<root-branch>`.

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ SSH.
 
 ```
 $ wt ls
-WORKTREE       STATUS       TITLE                                URI                                              TOKENS  ACTIVITY  AGE
-a3f8c12  attached     Rewrite Linux scheduler in Rust      localhost:5096/~/.../torvalds/linux            380k    now       3h
-b7e2a09  working      Implement quantum-safe cryptography  dev-desktop:5096/~/.../satoshi/bitcoin         240k    now       3d
-e1d4b83  committed    Autonomous drone delivery            localhost:5096/~/.../bezos/prime-air           85k     2h        12d
-4a0e9d6  dirty        Fix race in block allocator          localhost:5096/~/.../torvalds/linux            92k     5m        1d
-c9a1f57  merged *     Add exceptions to Go                 localhost:5096/~/.../robpike/go                45k     6h        1d
-d5b8e24  idle         Actually open OpenAI                 dev-desktop:5096/~/.../altman/openai           120k    3h        10d
-7f3b1c8  stale *      Ship Half-Life 3                     localhost:5096/~/.../gaben/hl3                 30k     2d        5d
-f2c7d91  idle         Write worktree session manager       localhost:5096/~/.../ellistarn/wt              150k    5m        4d
+WORKTREE	STATUS	TITLE	URI	TOKENS	ACTIVITY	AGE
+a3f8c12	attached	Rewrite Linux scheduler in Rust	localhost:5096/~/.../torvalds/linux	380k	now	3h
+b7e2a09	working	Implement quantum-safe cryptography	dev-desktop:5096/~/.../satoshi/bitcoin	240k	now	3d
+e1d4b83	committed	Autonomous drone delivery	localhost:5096/~/.../bezos/prime-air	85k	2h	12d
+4a0e9d6	dirty	Fix race in block allocator	localhost:5096/~/.../torvalds/linux	92k	5m	1d
+c9a1f57	merged *	Add exceptions to Go	localhost:5096/~/.../robpike/go	45k	6h	1d
+d5b8e24	idle	Actually open OpenAI	dev-desktop:5096/~/.../altman/openai	120k	3h	10d
+7f3b1c8	stale *	Ship Half-Life 3	localhost:5096/~/.../gaben/hl3	30k	2d	5d
+f2c7d91	idle	Write worktree session manager	localhost:5096/~/.../ellistarn/wt	150k	5m	4d
 ```
 
 Statuses, highest priority wins:

--- a/README.md
+++ b/README.md
@@ -18,23 +18,27 @@ c9a1f57  Add exceptions to Go                 merged *     6h        45k     /ho
 d5b8e24  Actually open OpenAI                 idle         10y       120k    /home/altman/.../openai/models             10y
 7f3b1c8  Refactor tokenizer                   stale *      2d        30k     [remote] /home/karpathy/.../llm.c          5d
 f2c7d91  -                                    empty *      -         -       /home/user/.../acme/toolkit                1d
-                                              # attached  — TUI client connected
-                                              # working   — agent generating
-                                              # dirty     — uncommitted changes in working tree
-                                              # merged *  — changes incorporated into upstream
-                                              # committed — unique commits not yet in upstream
-                                              # idle      — session exists, no unique commits
-                                              # stale *   — session inactive >4h, no unique commits
-                                              # empty *   — no session was ever created
 ```
+
+Statuses, highest priority wins:
+
+- **attached** — TUI client connected
+- **working** — agent generating
+- **dirty** — uncommitted changes in working tree
+- **merged** \* — changes incorporated into upstream
+- **committed** — unique commits not yet in upstream
+- **idle** — session exists, no unique commits
+- **stale** \* — session inactive >4h, no unique commits
+- **empty** \* — no session was ever created
 
 ## Install
 
 ```
-go install github.com/ellistarn/wt@latest
+go install github.com/ellistarn/wt@latest  # requires Go 1.24+, Git 2.38+
 ```
 
-Requires Go 1.24+, Git 2.38+, and `opencode` on PATH.
+Set `WT_REMOTE_HOST` for remote operations, `WT_OPENCODE_PORT` to override the
+default port (5096).
 
 ## Worktree lifecycle
 
@@ -50,31 +54,14 @@ wt                        Create a new local worktree and attach
 wt <name>                 Attach to an existing worktree (local or remote)
 wt -r <path>              Create a new remote worktree and attach
 wt ls                     List all worktrees (local and remote)
-wt -r ls                  List remote worktrees only
 wt diff <name>            Show changes on a worktree's branch
-wt rm                     Remove worktrees marked * in wt ls
-wt rm <name>              Remove a specific worktree
+wt rm                     Remove worktrees marked * (merged/stale/empty)
+wt rm <name>              Remove a specific worktree unconditionally
 
 Flags:
   -r, --remote              Operate on the remote dev desktop
   -h, --help                Show this help
 ```
 
-## Cleanup
-
-`wt rm` batch-removes worktrees whose status is marked `*`: merged (work
-landed), stale (inactive session, no commits), and empty (no session created).
-`wt ls` is the preview — what you see is what gets removed. `wt rm <name>`
-removes unconditionally.
-
-Merge detection compares against `origin/<root-branch>` and handles regular
-merges, squash merges, and rebase merges.
-
-## Configuration
-
-Environment variables:
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `WT_REMOTE_HOST` | For `-r` operations | — | SSH hostname of the remote dev desktop |
-| `WT_OPENCODE_PORT` | No | `5096` | OpenCode server port (local and remote) |
+`wt ls` is the preview for `wt rm`. Merge detection handles regular merges,
+squash merges, and rebase merges against `origin/<root-branch>`.

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ SSH.
 
 ```
 $ wt ls
-WORKTREE	STATUS	TITLE	URI	TOKENS	ACTIVITY	AGE
-a3f8c12	attached	Rewrite Linux scheduler in Rust	localhost:5096/~/.../torvalds/linux	380k	now	3h
-b7e2a09	working	Implement quantum-safe cryptography	dev-desktop:5096/~/.../satoshi/bitcoin	240k	now	3d
-e1d4b83	committed	Autonomous drone delivery	localhost:5096/~/.../bezos/prime-air	85k	2h	12d
-4a0e9d6	dirty	Fix race in block allocator	localhost:5096/~/.../torvalds/linux	92k	5m	1d
-c9a1f57	merged *	Add exceptions to Go	localhost:5096/~/.../robpike/go	45k	6h	1d
-d5b8e24	idle	Actually open OpenAI	dev-desktop:5096/~/.../altman/openai	120k	3h	10d
-7f3b1c8	stale *	Ship Half-Life 3	localhost:5096/~/.../gaben/hl3	30k	2d	5d
-f2c7d91	idle	Write worktree session manager	localhost:5096/~/.../ellistarn/wt	150k	5m	4d
+WORKTREE  STATUS     TITLE                                URI                                     TOKENS  ACTIVITY  AGE
+a3f8c12   attached   Rewrite Linux scheduler in Rust      localhost:5096/~/.../torvalds/linux     380k    now       3h
+b7e2a09   working    Implement quantum-safe cryptography  dev-desktop:5096/~/.../satoshi/bitcoin  240k    now       3d
+e1d4b83   committed  Autonomous drone delivery            localhost:5096/~/.../bezos/prime-air    85k     2h        12d
+4a0e9d6   dirty      Fix race in block allocator          localhost:5096/~/.../torvalds/linux     92k     5m        1d
+c9a1f57   merged *   Add exceptions to Go                 localhost:5096/~/.../robpike/go         45k     6h        1d
+d5b8e24   idle       Actually open OpenAI                 dev-desktop:5096/~/.../altman/openai    120k    3h        10d
+7f3b1c8   stale *    Ship Half-Life 3                     localhost:5096/~/.../gaben/hl3          30k     2d        5d
+f2c7d91   idle       Write worktree session manager       localhost:5096/~/.../ellistarn/wt       150k    5m        4d
 ```
 
 Statuses, highest priority wins:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ e1d4b83  Autonomous drone delivery            committed    2h        85k     /ho
 4a0e9d6  Fix race in block allocator          dirty        5m        92k     /home/torvalds/.../linux/mm                1d
 c9a1f57  Add exceptions to Go                 merged *     6h        45k     /home/robpike/.../golang/go                1d
 d5b8e24  Actually open OpenAI                 idle         10y       120k    /home/altman/.../openai/models             10y
-7f3b1c8  Refactor tokenizer                   stale *      2d        30k     [remote] /home/karpathy/.../llm.c          5d
-f2c7d91  -                                    empty *      -         -       /home/user/.../acme/toolkit                1d
+7f3b1c8  Finish TAOCP volume 5                stale *      2d        30k     /home/knuth/.../taocp/vol5                50y
+f2c7d91  Write worktree session manager       idle         5m        150k    /home/ellistarn/.../ellistarn/wt           4d
 ```
 
 Statuses, highest priority wins:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ SSH.
 
 ```
 $ wt ls
-WORKTREE       STATUS       TITLE                                URI                                           TOKENS  ACTIVITY  AGE
-a3f8c12  attached     Rewrite Linux scheduler in Rust      localhost:5096/~/.../linux/kernel            380k    now       3h
-b7e2a09  working      Implement quantum-safe cryptography  dev-desktop:5096/~/.../bitcoin/src          240k    now       3d
-e1d4b83  committed    Autonomous drone delivery            localhost:5096/~/.../amazon/prime-air       85k     2h        12d
-4a0e9d6  dirty        Fix race in block allocator          localhost:5096/~/.../linux/mm               92k     5m        1d
-c9a1f57  merged *     Add exceptions to Go                 localhost:5096/~/.../golang/go              45k     6h        1d
-d5b8e24  idle         Actually open OpenAI                 dev-desktop:5096/~/.../openai/models        120k    3h        10d
-7f3b1c8  stale *      Ship Half-Life 3                     localhost:5096/~/.../valve/hl3              30k     2d        5d
-f2c7d91  idle         Write worktree session manager       localhost:5096/~/.../ellistarn/wt           150k    5m        4d
+WORKTREE       STATUS       TITLE                                URI                                              TOKENS  ACTIVITY  AGE
+a3f8c12  attached     Rewrite Linux scheduler in Rust      localhost:5096/~/.../torvalds/linux            380k    now       3h
+b7e2a09  working      Implement quantum-safe cryptography  dev-desktop:5096/~/.../satoshi/bitcoin         240k    now       3d
+e1d4b83  committed    Autonomous drone delivery            localhost:5096/~/.../bezos/prime-air           85k     2h        12d
+4a0e9d6  dirty        Fix race in block allocator          localhost:5096/~/.../torvalds/linux            92k     5m        1d
+c9a1f57  merged *     Add exceptions to Go                 localhost:5096/~/.../robpike/go                45k     6h        1d
+d5b8e24  idle         Actually open OpenAI                 dev-desktop:5096/~/.../altman/openai           120k    3h        10d
+7f3b1c8  stale *      Ship Half-Life 3                     localhost:5096/~/.../gaben/hl3                 30k     2d        5d
+f2c7d91  idle         Write worktree session manager       localhost:5096/~/.../ellistarn/wt              150k    5m        4d
 ```
 
 Statuses, highest priority wins:

--- a/discover.go
+++ b/discover.go
@@ -55,17 +55,13 @@ func findWorktree(name string) (worktree.Entry, bool) {
 // returned so callers can gate classification on each repo's pull completing.
 // Returns any enrichment error — callers that make safety decisions must
 // check this; callers that only display can ignore it.
-func discoverAll(remoteOnly, pull bool) ([]worktree.Entry, pullResult, error) {
+func discoverAll(pull bool) ([]worktree.Entry, pullResult, error) {
 	host := os.Getenv("WT_REMOTE_HOST")
 
 	localCh := make(chan []worktree.Entry, 1)
 	remoteCh := make(chan remoteResult, 1)
 
-	if !remoteOnly {
-		go func() { localCh <- discover.ListLocal() }()
-	} else {
-		localCh <- nil
-	}
+	go func() { localCh <- discover.ListLocal() }()
 
 	if host != "" {
 		go func() {
@@ -73,9 +69,6 @@ func discoverAll(remoteOnly, pull bool) ([]worktree.Entry, pullResult, error) {
 			remoteCh <- remoteResult{entries, err}
 		}()
 	} else {
-		if remoteOnly {
-			die("WT_REMOTE_HOST is not set\n\nRemote operations require an SSH host. Set the environment variable:\n\n  export WT_REMOTE_HOST=your-dev-desktop")
-		}
 		remoteCh <- remoteResult{}
 	}
 
@@ -83,9 +76,6 @@ func discoverAll(remoteOnly, pull bool) ([]worktree.Entry, pullResult, error) {
 	local := <-localCh
 	rr := <-remoteCh
 	if rr.err != nil {
-		if remoteOnly {
-			die("%v", rr.err)
-		}
 		fmt.Fprintf(os.Stderr, "warning: %v\n", rr.err)
 	}
 
@@ -109,17 +99,15 @@ func discoverAll(remoteOnly, pull bool) ([]worktree.Entry, pullResult, error) {
 		pulled = make(pullResult)
 	}
 
-	if !remoteOnly {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := opencode.EnsureLocalServer(); err != nil {
-				localErr = fmt.Errorf("local server: %w", err)
-			} else if err := opencode.Enrich(opencode.LocalServerURL(), localEntries); err != nil {
-				localErr = fmt.Errorf("local session query: %w", err)
-			}
-		}()
-	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := opencode.EnsureLocalServer(); err != nil {
+			localErr = fmt.Errorf("local server: %w", err)
+		} else if err := opencode.Enrich(opencode.LocalServerURL(), localEntries); err != nil {
+			localErr = fmt.Errorf("local session query: %w", err)
+		}
+	}()
 
 	if host != "" && rr.err == nil {
 		wg.Add(1)

--- a/main.go
+++ b/main.go
@@ -36,11 +36,11 @@ func main() {
 
 	// Dispatch
 	if len(remaining) > 0 && remaining[0] == "ls" {
-		cmdLs(remote)
+		cmdLs()
 		return
 	}
 	if len(remaining) > 0 && remaining[0] == "rm" {
-		cmdRm(remaining[1:], remote)
+		cmdRm(remaining[1:])
 		return
 	}
 	if len(remaining) > 0 && remaining[0] == "diff" {
@@ -190,8 +190,8 @@ func cmdRemote(args []string) {
 }
 
 // cmdLs handles: wt ls
-func cmdLs(remoteOnly bool) {
-	all, pulled, enrichErr := discoverAll(remoteOnly, true)
+func cmdLs() {
+	all, pulled, enrichErr := discoverAll(true)
 	if enrichErr != nil {
 		die("%v", enrichErr)
 	}
@@ -282,7 +282,6 @@ Usage:
   wt <name>                 Attach to an existing worktree (local or remote)
   wt -r <path>              Create a new remote worktree and attach
   wt ls                     List all worktrees (local and remote)
-  wt -r ls                  List remote worktrees only
   wt diff <name>            Show changes on a worktree's branch
   wt rm                     Remove worktrees marked * in wt ls
   wt rm <name>              Remove a specific worktree

--- a/rm.go
+++ b/rm.go
@@ -15,14 +15,14 @@ import (
 )
 
 // cmdRm handles: wt rm [name]
-func cmdRm(args []string, remoteOnly bool) {
+func cmdRm(args []string) {
 	if len(args) > 1 {
 		die("unexpected argument: %s", args[1])
 	}
 	if len(args) == 1 {
 		cmdRmTargeted(args[0])
 	} else {
-		cmdRmBatch(remoteOnly)
+		cmdRmBatch()
 	}
 }
 
@@ -184,8 +184,8 @@ func isRemovable(status string) bool {
 	return status == "merged" || status == "stale" || status == "empty"
 }
 
-func cmdRmBatch(remoteOnly bool) {
-	all, pulled, enrichErr := discoverAll(remoteOnly, true)
+func cmdRmBatch() {
+	all, pulled, enrichErr := discoverAll(true)
 	if enrichErr != nil {
 		die("cannot determine session status: %v", enrichErr)
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -665,14 +665,7 @@ func TestRemote_HostNotSet(t *testing.T) {
 
 	base := []string{"WT_REMOTE_HOST=", "HOME=" + t.TempDir()}
 
-	out, code := wtRaw(t, base, "-r", "ls")
-	if code == 0 {
-		t.Fatal("expected non-zero exit code")
-	}
-	assertContains(t, out, "WT_REMOTE_HOST is not set")
-	assertContains(t, out, "export WT_REMOTE_HOST=")
-
-	out, code = wtRaw(t, base, "-r", "/tmp/fake")
+	out, code := wtRaw(t, base, "-r", "/tmp/fake")
 	if code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}
@@ -688,13 +681,7 @@ func TestRemote_HostUnreachable(t *testing.T) {
 
 	base := []string{"WT_REMOTE_HOST=wt-nonexistent-host-test", "HOME=" + t.TempDir()}
 
-	out, code := wtRaw(t, base, "-r", "ls")
-	if code == 0 {
-		t.Fatal("expected non-zero exit code")
-	}
-	assertContains(t, out, "cannot connect to remote host")
-
-	out, code = wtRaw(t, base, "-r", "/tmp/fake")
+	out, code := wtRaw(t, base, "-r", "/tmp/fake")
 	if code == 0 {
 		t.Fatal("expected non-zero exit code")
 	}

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -160,7 +160,7 @@ func TestSSH_Ls_UnifiedStatus(t *testing.T) {
 	env.push("ssh-merged")
 	env.mergeToMain("ssh-merged")
 
-	out := env.wt("-r", "ls")
+	out := env.wt("ls")
 	t.Log("SSH ls output:\n" + out)
 
 	assertContains(t, out, "ssh-clean")
@@ -183,8 +183,8 @@ func TestSSH_RemoteSessionQuery(t *testing.T) {
 	wt := env.addWorktree("ssh-session")
 	env.createSession(wt)
 
-	// wt ls -r should show the session
-	out := env.wt("-r", "ls")
+	// wt ls should show the session
+	out := env.wt("ls")
 	t.Log("SSH ls output:\n" + out)
 
 	assertContains(t, out, "ssh-session")
@@ -207,7 +207,7 @@ func TestSSH_RemoteSessionQuery(t *testing.T) {
 	}
 
 	// wt rm should skip it (session exists, default 4h stale threshold)
-	out = env.wt("-r", "rm", "--dry-run")
+	out = env.wt("rm", "--dry-run")
 	t.Log("SSH rm dry-run output:\n" + out)
 	assertContains(t, out, "ssh-session")
 	assertContains(t, out, "keep (")


### PR DESCRIPTION
## Summary

- Expand opener to explain the problem (agent isolation) and the solution (worktree-per-agent bound to OpenCode sessions)
- Update `wt ls` example to showcase all 8 statuses with an inline legend
- Add Install section with `go install` and prerequisites
- Add Worktree lifecycle section explaining the branching model and pull semantics
- Expand Commands to the full set (was missing `rm`, `diff`, `-r ls`, flags)
- Add Cleanup section explaining `wt rm` batch semantics and merge detection