### PR TITLE
Improve README and remove wt -r ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,6 @@ go install github.com/ellistarn/wt@latest  # requires Go 1.24+, Git 2.38+
 Set `WT_REMOTE_HOST` for remote operations, `WT_OPENCODE_PORT` to override the
 default port (5096).
 
-## Worktree lifecycle
-
-Each worktree branches from whatever the repo root has checked out (typically
-main), with `origin/<root-branch>` as its merge target. `wt` pulls the repo
-before creating a worktree and again after you exit, so worktrees start from the
-latest remote state and merge detection stays accurate against a fresh upstream.
-
 ## Commands
 
 ```
@@ -62,4 +55,32 @@ Flags:
   -r, --remote              Operate on the remote dev desktop
   -h, --help                Show this help
 ```
+
+## Worktree lifecycle
+
+Each worktree branches from whatever the repo root has checked out (typically
+main), with `origin/<root-branch>` as its merge target. `wt` pulls the repo
+before creating a worktree and again after you exit, so worktrees start from the
+latest remote state and merge detection stays accurate against a fresh upstream.
+
+## How it works
+
+`wt` glues together Git, OpenCode, and SSH.
+
+**OpenCode** — `wt` auto-starts `opencode serve` as a detached process on first
+use, locally and on the remote host via SSH. One server per machine, shared
+across all worktrees and repos. Sessions persist in the OpenCode database — `wt
+rm` deletes the worktree and branch but never touches session history. Reattach
+with `wt <name>`; the TUI reconnects and loads full history, including work the
+agent completed while disconnected.
+
+**Git** — Every command pulls the repo root (`git pull --ff-only --prune`).
+Create adds a worktree at `<repo>/.worktrees/<name>` on a new branch with
+`origin/<root-branch>` as its upstream. Remove deletes the worktree directory
+and force-deletes the branch.
+
+**SSH** — For remote operations, `wt` maintains a long-lived SSH tunnel (port
+5097 to remote 5096) with a mux control socket for connection reuse. Health-checked
+and restarted automatically. All remote git and server operations go through the
+mux, amortizing SSH handshake costs.
 

--- a/README.md
+++ b/README.md
@@ -67,17 +67,18 @@ latest remote state and merge detection stays accurate against a fresh upstream.
 
 `wt` glues together Git, OpenCode, and SSH.
 
-**OpenCode** — `wt` auto-starts `opencode serve` as a detached process on first
-use, locally and on the remote host via SSH. One server per machine, shared
-across all worktrees and repos. Sessions persist in the OpenCode database — `wt
-rm` deletes the worktree and branch but never touches session history. Reattach
-with `wt <name>`; the TUI reconnects and loads full history, including work the
-agent completed while disconnected.
-
 **Git** — Every command pulls the repo root (`git pull --ff-only --prune`).
 Create adds a worktree at `<repo>/.worktrees/<name>` on a new branch with
 `origin/<root-branch>` as its upstream. Remove deletes the worktree directory
 and force-deletes the branch.
+
+**OpenCode** — `wt` auto-starts `opencode serve` on port 5096 as a detached
+process on first use, locally and on the remote host via SSH. One server per
+machine, shared across all worktrees and repos. If OpenCode is already running
+on a different port, set `WT_OPENCODE_PORT` to match. Sessions persist in the
+OpenCode database — `wt rm` deletes the worktree and branch but never touches
+session history. Reattach with `wt <name>`; the TUI reconnects and loads full
+history, including work the agent completed while disconnected.
 
 **SSH** — For remote operations, `wt` maintains a long-lived SSH tunnel (port
 5097 to remote 5096) with a mux control socket for connection reuse. Health-checked


### PR DESCRIPTION
## Summary

- Rewrite README: pithy opener, install section, full command reference, status legend as bullets, worktree lifecycle, and new "How it works" section covering OpenCode/Git/SSH
- Remove `wt -r ls` — `wt ls` always shows both local and remote worktrees. Drops the `remoteOnly` parameter from `discoverAll`, `cmdLs`, and `cmdRm`
- Fix `wt ls` example to match actual column order (`STATUS` before `TITLE`), URI format (`host:port/~/.../owner/repo`), and sort order (by activity descending)