### PR TITLE
Move worktrees from nested to sibling layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 
 # Agent state
 .opencode/
-.worktrees/

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Flags:
 `wt` glues together Git, OpenCode, and SSH.
 
 **Git** — Every command pulls the repo root (`git pull --ff-only --prune`).
-Create adds a worktree at `<repo>/.worktrees/<name>` on a new branch with
+Create adds a worktree at `<repo>-<name>` (a sibling directory) on a new branch with
 `origin/<root-branch>` as its upstream, so worktrees always start from the
 latest remote state and merge detection stays accurate against a fresh upstream.
 Remove deletes the worktree directory and force-deletes the branch.

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -18,9 +18,10 @@ resuming trivial.
 
 ## Model
 
-A **worktree** is a git worktree at `<repo>/.worktrees/<name>`, where `name`
-equals the branch name. The worktree directory is the primary key. Worktrees are
-created per unit of work and cleaned up separately when the branch lands.
+A **worktree** is a git worktree at `<repo>-<name>`, a sibling of the repo
+directory, where `name` equals the branch name. The worktree directory is the
+primary key. Worktrees are created per unit of work and cleaned up separately
+when the branch lands.
 
 The **root branch** is whatever branch the repo root has checked out at worktree
 creation time (typically `main`). Each worktree records `origin/<root-branch>` as
@@ -65,7 +66,7 @@ laptop
   opencode serve                     # auto-started by wt, port 5096
        │
   wt <name> ──> opencode attach http://localhost:5096
-                  --dir <repo>/.worktrees/<name>
+                  --dir <repo>-<name>
                   --session <id>
 ```
 
@@ -137,7 +138,7 @@ Create or resume a worktree.
   latest remote state.
 - With `name`: pull the repo's current branch (best-effort) to keep it fresh
   for future worktree creation and merge detection. Resume
-  `<repo>/.worktrees/<name>`. Attach. Pull again on exit.
+  `<repo>-<name>`. Attach. Pull again on exit.
 
 ### `wt -r <path>`
 

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func cmdLocal(args []string) {
 			die("not in a git repo")
 		}
 		name := worktree.GenerateName()
-		wtDir := repo + "/.worktrees/" + name
+		wtDir := worktree.WorktreeDir(repo, name)
 		if err := git.Pull("", repo); err != nil {
 			die("failed to pull: %v", err)
 		}
@@ -159,7 +159,7 @@ func cmdRemote(args []string) {
 
 	// Create new worktree
 	name := worktree.GenerateName()
-	wtDir := repo + "/.worktrees/" + name
+	wtDir := worktree.WorktreeDir(repo, name)
 	if err := git.Pull(host, repo); err != nil {
 		die("failed to pull: %v", err)
 	}

--- a/pkg/discover/local.go
+++ b/pkg/discover/local.go
@@ -20,12 +20,12 @@ func ListLocal() []worktree.Entry {
 		home = resolved
 	}
 
-	// Find .worktrees directories by walking with os.ReadDir, which uses
-	// the d_type field from readdir to check IsDir() without stat syscalls.
+	// Find git repos by walking for .git directories. Uses os.ReadDir
+	// which reads d_type from readdir to check IsDir() without stat syscalls.
 	var repos []string
 	seen := make(map[string]bool)
 	var repoMu sync.Mutex
-	findWorktreeDirs(home, 10, 16, func(repo string) {
+	findGitRepos(home, 10, 16, func(repo string) {
 		repoMu.Lock()
 		defer repoMu.Unlock()
 		if !seen[repo] {
@@ -52,7 +52,10 @@ func ListLocal() []worktree.Entry {
 	return all
 }
 
-// findWorktreeDirs walks directories looking for .worktrees entries.
+// findGitRepos walks directories looking for .git entries (directories or files).
+// A .git directory indicates a repo root; a .git file indicates a worktree
+// checkout (which is found via its parent repo's git worktree list).
+//
 // Uses three generic pruning strategies to stay fast on any filesystem:
 //  1. Hidden directories (starting with ".") are skipped.
 //  2. Git repo roots (.git detected) are leaf nodes — their children are
@@ -66,7 +69,7 @@ func ListLocal() []worktree.Entry {
 // A fixed pool of workers processes a directory queue so wall time scales
 // with tree depth rather than total directory count, without goroutine
 // explosion.
-func findWorktreeDirs(root string, maxDepth, workers int, fn func(repo string)) {
+func findGitRepos(root string, maxDepth, workers int, fn func(repo string)) {
 	type item struct {
 		dir   string
 		depth int
@@ -140,18 +143,18 @@ func walkDir(dir string, depth int, fn func(repo string)) []string {
 		if !e.IsDir() {
 			continue
 		}
-		if name == ".worktrees" {
-			fn(dir)
-			continue
-		}
 		if !strings.HasPrefix(name, ".") {
 			children = append(children, name)
 		}
 	}
 
-	if hasGit && depth > 0 {
-		return nil
+	if hasGit {
+		fn(dir)
+		if depth > 0 {
+			return nil
+		}
 	}
+
 	if len(children) > 100 {
 		return nil
 	}
@@ -170,28 +173,65 @@ func listInRepo(repo string) []worktree.Entry {
 func parseWorktreeList(porcelain, repo string) []worktree.Entry {
 	var entries []worktree.Entry
 	var currentWT string
-	wtPrefix := repo + "/.worktrees/"
+	var currentBranch string
 
 	for _, line := range strings.Split(porcelain, "\n") {
 		if strings.HasPrefix(line, "worktree ") {
 			currentWT = strings.TrimPrefix(line, "worktree ")
 		}
-		if strings.HasPrefix(line, "branch ") && currentWT != "" {
-			if strings.HasPrefix(currentWT, wtPrefix) {
-				e := worktree.Entry{
-					Name: strings.TrimPrefix(currentWT, wtPrefix),
-					Dir:  currentWT,
-					Repo: repo,
-				}
-				// Stat the .git file to get creation time.
-				// Git creates this file when the worktree is added; it doesn't change.
-				if info, err := os.Stat(filepath.Join(currentWT, ".git")); err == nil {
-					e.CreatedAt = info.ModTime()
-				}
+		if strings.HasPrefix(line, "branch ") {
+			currentBranch = strings.TrimPrefix(line, "branch ")
+			// Strip refs/heads/ prefix
+			currentBranch = strings.TrimPrefix(currentBranch, "refs/heads/")
+		}
+		if line == "" && currentWT != "" {
+			if e, ok := matchWorktree(currentWT, currentBranch, repo); ok {
 				entries = append(entries, e)
 			}
 			currentWT = ""
+			currentBranch = ""
+		}
+	}
+	// Handle final block if porcelain doesn't end with a blank line.
+	if currentWT != "" {
+		if e, ok := matchWorktree(currentWT, currentBranch, repo); ok {
+			entries = append(entries, e)
 		}
 	}
 	return entries
+}
+
+// matchWorktree checks if a worktree path is wt-managed and returns the Entry.
+func matchWorktree(wtPath, branch, repo string) (worktree.Entry, bool) {
+	if branch == "" {
+		return worktree.Entry{}, false
+	}
+	// Sibling layout: <parent>/<repobase>-<name>
+	if wtPath == worktree.WorktreeDir(repo, branch) {
+		return newEntry(branch, wtPath, repo), true
+	}
+	// COMPAT: legacy layout <repo>/.worktrees/<name>. Remove once all
+	// legacy worktrees have been drained via wt rm.
+	if matchLegacyWorktree(wtPath, branch, repo) {
+		return newEntry(branch, wtPath, repo), true
+	}
+	return worktree.Entry{}, false
+}
+
+func newEntry(name, dir, repo string) worktree.Entry {
+	e := worktree.Entry{Name: name, Dir: dir, Repo: repo}
+	if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		e.CreatedAt = info.ModTime()
+	}
+	return e
+}
+
+// COMPAT: matchLegacyWorktree matches the old <repo>/.worktrees/<name> layout.
+// Remove once all legacy worktrees have been drained via wt rm.
+func matchLegacyWorktree(wtPath, branch, repo string) bool {
+	prefix := repo + "/.worktrees/"
+	if !strings.HasPrefix(wtPath, prefix) {
+		return false
+	}
+	return strings.TrimPrefix(wtPath, prefix) == branch
 }

--- a/pkg/discover/remote.go
+++ b/pkg/discover/remote.go
@@ -2,7 +2,6 @@ package discover
 
 import (
 	"fmt"
-	"path"
 	"strconv"
 	"strings"
 
@@ -11,25 +10,33 @@ import (
 )
 
 // ListRemote finds all worktrees on the remote host.
-// Fans out find across top-level home directories in parallel so wall time
-// scales with tree depth, not breadth — matching the local walk strategy.
+// Finds git repos, runs git worktree list on each, and filters for
+// wt-managed worktrees in sibling layout (<repo>-<name>) or legacy
+// layout (<repo>/.worktrees/<name>).
 // Collects worktree metadata including timestamps in a single SSH call.
 func ListRemote(host string) ([]worktree.Entry, error) {
 	script := `
 set -eu
 home=$(cd "$HOME" && pwd -P)
 
-# Parallel find: fan out across top-level dirs, same as local worker pool.
-# Writes to pipe are atomic for lines < PIPE_BUF (4096), so concurrent
-# finds produce clean output.
+# Check if a directory is a git repo and list its wt-managed worktrees.
+# Matches both sibling layout (<parent>/<repobase>-<name>) and legacy
+# layout (<repo>/.worktrees/<name>).
 process_repo() {
     repo="$1"
+    repobase=$(basename "$repo")
+    repodir=$(dirname "$repo")
     if [ -d "$repo/.git" ] || [ -f "$repo/.git" ]; then
-        git -C "$repo" worktree list --porcelain 2>/dev/null | awk -v repo="$repo" '
+        git -C "$repo" worktree list --porcelain 2>/dev/null | awk -v repo="$repo" -v repobase="$repobase" -v repodir="$repodir" '
             /^worktree / { wt=$2 }
             /^branch / {
                 br=$2; sub(/^refs\/heads\//, "", br)
-                if (wt ~ /\/.worktrees\//) {
+                # Sibling layout: <parent>/<repobase>-<name>
+                match_sibling = (wt == repodir "/" repobase "-" br)
+                # COMPAT: legacy layout <repo>/.worktrees/<name>.
+                # Remove once all legacy worktrees have been drained via wt rm.
+                match_legacy = (wt == repo "/.worktrees/" br)
+                if (match_sibling || match_legacy) {
                     cmd = "stat -c %Y \"" wt "/.git\" 2>/dev/null || stat -f %m \"" wt "/.git\" 2>/dev/null || echo 0"
                     cmd | getline ts
                     close(cmd)
@@ -40,19 +47,21 @@ process_repo() {
     fi
 }
 
+# Find git repos by looking for .git directories.
+# Fan out find across top-level dirs in parallel, same as local worker pool.
 {
-    # Check home root for .worktrees
-    [ -d "$home/.worktrees" ] && echo "$home/.worktrees"
+    # Check home root
+    [ -d "$home/.git" ] && echo "$home"
     # Fan out find across each top-level dir
     for d in "$home"/*/; do
         [ -d "$d" ] || continue
         name=$(basename "$d")
         case "$name" in .*) continue ;; esac
-        find "$d" -maxdepth 9 -type d \( -name .worktrees -print -prune -o -name '.*' -prune \) &
+        find "$d" -maxdepth 9 -type d \( -name .git -printf '%h\n' -prune -o -name '.*' -prune \) 2>/dev/null &
     done
     wait
-} | while IFS= read -r wt_dir; do
-    process_repo "${wt_dir%/.worktrees}"
+} | sort -u | while IFS= read -r repo; do
+    process_repo "$repo"
 done
 `
 	out, err := ssh.Run(host, script)
@@ -71,7 +80,7 @@ done
 		}
 		e := worktree.Entry{
 			Dir:  parts[0],
-			Name: path.Base(parts[0]),
+			Name: parts[1],
 			Repo: parts[2],
 			Host: host,
 		}

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -110,7 +110,7 @@ func TestPrintTable(t *testing.T) {
 		{
 			Entry: worktree.Entry{
 				Name:      "a3f8c12",
-				Dir:       "/home/user/src/github.com/acme/project/.worktrees/a3f8c12",
+				Dir:       "/home/user/src/github.com/acme/project-a3f8c12",
 				Repo:      "/home/user/src/github.com/acme/project",
 				Status:    "idle",
 				Title:     "Fix auth handler",
@@ -123,7 +123,7 @@ func TestPrintTable(t *testing.T) {
 		{
 			Entry: worktree.Entry{
 				Name:      "b7e2a09",
-				Dir:       "/home/user/src/github.com/acme/project/.worktrees/b7e2a09",
+				Dir:       "/home/user/src/github.com/acme/project-b7e2a09",
 				Repo:      "/home/user/src/github.com/acme/project",
 				CreatedAt: now.Add(-1 * time.Hour),
 			},

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -3,13 +3,17 @@ package git
 import (
 	"fmt"
 	"os"
+
+	"github.com/ellistarn/wt/pkg/worktree"
 )
 
-// WorktreeAdd creates a new worktree at <repo>/.worktrees/<name> on branch <name>.
-// Sets the new branch's upstream tracking ref to origin/<root-branch>, where
-// root-branch is whatever the repo root has checked out.
+// WorktreeAdd creates a new worktree as a sibling of the repo on branch <name>.
+// The worktree lives at <parent>/<repobasename>-<name>. Sets the new branch's
+// upstream tracking ref to origin/<root-branch>, where root-branch is whatever
+// the repo root has checked out.
 func WorktreeAdd(host, repo, name string) error {
-	args := []string{"worktree", "add", ".worktrees/" + name, "-b", name}
+	wtDir := worktree.WorktreeDir(repo, name)
+	args := []string{"worktree", "add", wtDir, "-b", name}
 	out, err := runCapture(host, repo, args...)
 	if err != nil {
 		return err
@@ -41,10 +45,10 @@ func Pull(host, repo string) error {
 }
 
 // WorktreeRemove removes the worktree directory and force-deletes the branch.
+// wtDir is the worktree's actual path on disk (may be sibling or legacy layout).
 // The caller's classification logic has already confirmed safety.
-func WorktreeRemove(host, repo, name string) error {
-	wtPath := repo + "/.worktrees/" + name
-	args := []string{"worktree", "remove", wtPath}
+func WorktreeRemove(host, repo, name, wtDir string) error {
+	args := []string{"worktree", "remove", wtDir}
 	out, err := runCapture(host, repo, args...)
 	if err != nil {
 		return fmt.Errorf("git worktree remove: %w", err)
@@ -63,9 +67,9 @@ func WorktreeRemove(host, repo, name string) error {
 }
 
 // WorktreeForceRemove removes the worktree and branch without safety checks.
-func WorktreeForceRemove(host, repo, name string) error {
-	wtPath := repo + "/.worktrees/" + name
-	args := []string{"worktree", "remove", "--force", wtPath}
+// wtDir is the worktree's actual path on disk (may be sibling or legacy layout).
+func WorktreeForceRemove(host, repo, name, wtDir string) error {
+	args := []string{"worktree", "remove", "--force", wtDir}
 	out, err := runCapture(host, repo, args...)
 	if err != nil {
 		return fmt.Errorf("git worktree remove --force: %w", err)

--- a/pkg/opencode/opencode_test.go
+++ b/pkg/opencode/opencode_test.go
@@ -49,13 +49,13 @@ func TestParseAttachDir(t *testing.T) {
 	}{
 		{
 			name:    "node wrapper",
-			line:    "/usr/local/bin/node /usr/local/bin/opencode attach http://localhost:5096 --dir /home/me/.worktrees/fix-auth",
-			wantDir: "/home/me/.worktrees/fix-auth",
+			line:    "/usr/local/bin/node /usr/local/bin/opencode attach http://localhost:5096 --dir /home/me/project-fix-auth",
+			wantDir: "/home/me/project-fix-auth",
 		},
 		{
 			name:    "native binary",
-			line:    "/usr/lib/opencode/bin/opencode attach http://localhost:5096 --dir /home/me/.worktrees/fix-auth",
-			wantDir: "/home/me/.worktrees/fix-auth",
+			line:    "/usr/lib/opencode/bin/opencode attach http://localhost:5096 --dir /home/me/project-fix-auth",
+			wantDir: "/home/me/project-fix-auth",
 		},
 		{
 			name: "bare opencode ignored",
@@ -239,7 +239,7 @@ func TestFetchSessionStatus_NoMessages(t *testing.T) {
 func TestEnrich_RegressionCrossProject(t *testing.T) {
 	session := Session{
 		ID:        "sess-1",
-		Directory: "/home/user/kro/.worktrees/a3f8c12",
+		Directory: "/home/user/kro-a3f8c12",
 		Title:     "fix auth bug",
 		Time: struct {
 			Created int64 `json:"created"`
@@ -268,11 +268,11 @@ func TestEnrich_RegressionCrossProject(t *testing.T) {
 	entries := []worktree.Entry{
 		{
 			Name: "a3f8c12",
-			Dir:  "/home/user/kro/.worktrees/a3f8c12",
+			Dir:  "/home/user/kro-a3f8c12",
 		},
 		{
 			Name: "b7e2a09",
-			Dir:  "/home/user/wt/.worktrees/b7e2a09", // no session for this one
+			Dir:  "/home/user/wt-b7e2a09", // no session for this one
 		},
 	}
 
@@ -299,7 +299,7 @@ func TestEnrich_RegressionStaleTokens(t *testing.T) {
 
 	session := Session{
 		ID:        "sess-stale",
-		Directory: "/home/user/wt/.worktrees/c4d9e01",
+		Directory: "/home/user/wt-c4d9e01",
 		Title:     "stale session with tokens",
 		Time: struct {
 			Created int64 `json:"created"`
@@ -353,7 +353,7 @@ func TestEnrich_RegressionStaleTokens(t *testing.T) {
 	entries := []worktree.Entry{
 		{
 			Name: "c4d9e01",
-			Dir:  "/home/user/wt/.worktrees/c4d9e01",
+			Dir:  "/home/user/wt-c4d9e01",
 		},
 	}
 

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -3,9 +3,17 @@ package worktree
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"path"
 	"sort"
 	"time"
 )
+
+// WorktreeDir returns the absolute path of a worktree given the repo root
+// and worktree name. Worktrees live as siblings of the repo:
+// <parent>/<repobasename>-<name>.
+func WorktreeDir(repo, name string) string {
+	return path.Join(path.Dir(repo), path.Base(repo)+"-"+name)
+}
 
 // Entry represents a discovered worktree.
 type Entry struct {

--- a/rm.go
+++ b/rm.go
@@ -213,7 +213,7 @@ func cmdRmBatch() {
 
 		if isRemovable(status) {
 			host := hostFor(e)
-			if err := git.WorktreeRemove(host, e.Repo, e.Name); err != nil {
+			if err := git.WorktreeRemove(host, e.Repo, e.Name, e.Dir); err != nil {
 				errMsg = strings.ReplaceAll(strings.TrimSpace(err.Error()), "\n", " ")
 			} else {
 				status = "removed"
@@ -267,7 +267,7 @@ func cmdRmTargeted(name string) {
 		die("worktree %q not found", name)
 	}
 	host := hostFor(entry)
-	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name); err != nil {
+	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name, entry.Dir); err != nil {
 		die("%v", err)
 	}
 	display.PrintTable([]display.Row{{

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -89,7 +89,7 @@ func newTestEnv(t *testing.T) *testEnv {
 
 func (e *testEnv) addWorktree(name string) string {
 	e.t.Helper()
-	wtDir := filepath.Join(e.repo, ".worktrees", name)
+	wtDir := filepath.Join(filepath.Dir(e.repo), filepath.Base(e.repo)+"-"+name)
 	gitCmd(e.t, e.repo, "worktree", "add", wtDir, "-b", name)
 	// Set upstream tracking to match WorktreeAdd behavior.
 	rootBranch := strings.TrimSpace(gitCmd(e.t, e.repo, "rev-parse", "--abbrev-ref", "HEAD"))
@@ -253,7 +253,7 @@ func (e *testEnv) wt(args ...string) string {
 }
 
 func (e *testEnv) worktreeExists(name string) bool {
-	_, err := os.Stat(filepath.Join(e.repo, ".worktrees", name))
+	_, err := os.Stat(filepath.Join(filepath.Dir(e.repo), filepath.Base(e.repo)+"-"+name))
 	return err == nil
 }
 

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -58,12 +59,14 @@ func newSSHTestEnv(t *testing.T) *sshTestEnv {
 
 func (e *sshTestEnv) addWorktree(name string) string {
 	e.t.Helper()
-	wtDir := e.repo + "/.worktrees/" + name
+	repoBase := filepath.Base(e.repo)
+	repoDir := filepath.Dir(e.repo)
+	wtDir := repoDir + "/" + repoBase + "-" + name
 	sshRun(e.t, e.host, fmt.Sprintf(
-		"cd %s && git worktree add .worktrees/%s -b %s && "+
+		"cd %s && git worktree add %s -b %s && "+
 			"root=$(git rev-parse --abbrev-ref HEAD) && "+
 			"git branch --set-upstream-to=origin/$root %s",
-		e.repo, name, name, name))
+		e.repo, wtDir, name, name))
 	return wtDir
 }
 
@@ -113,7 +116,9 @@ func (e *sshTestEnv) wt(args ...string) string {
 }
 
 func (e *sshTestEnv) worktreeExists(name string) bool {
-	_, err := sshRunErr(e.host, fmt.Sprintf("test -d %s/.worktrees/%s", e.repo, name))
+	repoBase := filepath.Base(e.repo)
+	repoDir := filepath.Dir(e.repo)
+	_, err := sshRunErr(e.host, fmt.Sprintf("test -d %s/%s-%s", repoDir, repoBase, name))
 	return err == nil
 }
 


### PR DESCRIPTION
## Summary

- Worktrees now live at `<repo>-<name>` (siblings) instead of `<repo>/.worktrees/<name>` (children), avoiding build system conflicts where nested checkouts confuse tools that walk the repo tree.
- Discovery finds git repos by `.git` directories and filters `git worktree list` output by the sibling path convention instead of the `.worktrees/` prefix.
- `WorktreeDir()` in `pkg/worktree` centralizes the path computation used by all 12 changed files.