### PR TITLE
Prefix worktree names with project name for identification

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/ellistarn/wt/pkg/discover"
@@ -42,8 +43,17 @@ func findWorktree(name string) (worktree.Entry, bool) {
 	}
 
 	all := append(local, rr.entries...)
+	// Exact match first, then suffix match so users can type just the
+	// hash portion of a project-scoped name (e.g. "799291a" matches
+	// "Jetstream-799291a").
 	for _, e := range all {
 		if e.Name == name {
+			return e, true
+		}
+	}
+	suffix := "-" + name
+	for _, e := range all {
+		if strings.HasSuffix(e.Name, suffix) {
 			return e, true
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -80,7 +81,7 @@ func cmdLocal(args []string, root string) {
 		if err != nil {
 			die("not in a git repo")
 		}
-		name := worktree.GenerateName()
+		name := worktree.GenerateName(filepath.Base(repo))
 		if root == "" {
 			root = worktree.DefaultRoot
 		}
@@ -173,7 +174,7 @@ func cmdRemote(args []string, root string) {
 	}
 
 	// Create new worktree
-	name := worktree.GenerateName()
+	name := worktree.GenerateName(filepath.Base(args[0]))
 	if root == "" {
 		root = worktree.DefaultRoot
 	}

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -33,15 +33,17 @@ type Entry struct {
 	Attached  bool      // true if a TUI client is attached to this worktree
 }
 
-// GenerateName returns a short random hex name for a new worktree.
-// 7 hex chars = 28 bits of entropy (~268M namespace), sufficient for
-// collision-free operation across 100k+ worktrees.
-func GenerateName() string {
+// GenerateName returns a project-scoped name for a new worktree.
+// Format: <project>-<hex> where project is the caller-supplied name
+// and hex is 7 random hex chars (28 bits of entropy, ~268M namespace).
+// The hyphen keeps the name flat — the same string is used as the git
+// branch name, the worktree directory name, and the display label.
+func GenerateName(project string) string {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		panic("crypto/rand failed: " + err.Error())
 	}
-	return hex.EncodeToString(b[:])[:7]
+	return project + "-" + hex.EncodeToString(b[:])[:7]
 }
 
 // Sort sorts entries by most recent activity (UpdatedAt), newest first.

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestGenerateName(t *testing.T) {
-	hex7 := regexp.MustCompile(`^[0-9a-f]{7}$`)
+	nameRe := regexp.MustCompile(`^MyProject-[0-9a-f]{7}$`)
 	seen := map[string]bool{}
 	for i := 0; i < 1000; i++ {
-		name := GenerateName()
-		if !hex7.MatchString(name) {
-			t.Fatalf("GenerateName() = %q, want 7 lowercase hex chars", name)
+		name := GenerateName("MyProject")
+		if !nameRe.MatchString(name) {
+			t.Fatalf("GenerateName() = %q, want MyProject-<7 hex chars>", name)
 		}
 		seen[name] = true
 	}


### PR DESCRIPTION
## Summary
- Worktree names change from bare hex (e.g. `799291a`) to project-scoped names (e.g. `Jetstream-799291a`) so the project is immediately visible in `wt ls` output and URI paths.
- Project name comes from the repo directory basename (local) or the user-supplied path basename (remote: `wt -r .../Jetstream` → `Jetstream-<hex>`).
- `findWorktree` gains suffix matching so users can still type just the hash to attach (`wt 799291a` matches `Jetstream-799291a`).