### PR TITLE
Fix orphaned branches by decoupling worktree removal from branch deletion

### DIFF
--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -44,39 +44,43 @@ func Pull(host, repo string) error {
 // wtDir is the worktree's actual path on disk (may be sibling or child layout).
 // The caller's classification logic has already confirmed safety.
 func WorktreeRemove(host, repo, name, wtDir string) error {
-	args := []string{"worktree", "remove", wtDir}
-	out, err := runCapture(host, repo, args...)
-	if err != nil {
-		return fmt.Errorf("git worktree remove: %w", err)
-	}
-	logCmd(host, repo, out, args...)
-	// Force delete the branch. The caller's classification logic has already
-	// confirmed this worktree is safe to remove (merged, stale, or empty),
-	// which is stricter than git's own -d merge check.
-	branchArgs := []string{"branch", "-D", name}
-	out, err = runGit(host, repo, branchArgs...)
-	logCmd(host, repo, out, branchArgs...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: branch delete failed for %s: %v\n", name, err)
-	}
+	removeWorktreeAndBranch(host, repo, name, wtDir, false)
 	return nil
 }
 
 // WorktreeForceRemove removes the worktree and branch without safety checks.
 // wtDir is the worktree's actual path on disk (may be sibling or child layout).
 func WorktreeForceRemove(host, repo, name, wtDir string) error {
-	args := []string{"worktree", "remove", "--force", wtDir}
+	removeWorktreeAndBranch(host, repo, name, wtDir, true)
+	return nil
+}
+
+// removeWorktreeAndBranch deregisters the worktree and deletes its branch.
+// The two operations are independent — a missing worktree directory must not
+// prevent the branch from being cleaned up.
+func removeWorktreeAndBranch(host, repo, name, wtDir string, force bool) {
+	// Step 1: try to deregister the worktree directory.
+	args := []string{"worktree", "remove", wtDir}
+	if force {
+		args = []string{"worktree", "remove", "--force", wtDir}
+	}
 	out, err := runCapture(host, repo, args...)
 	if err != nil {
-		return fmt.Errorf("git worktree remove --force: %w", err)
+		// Directory already gone or other issue — prune stale registrations
+		// so git no longer thinks the branch is checked out.
+		fmt.Fprintf(os.Stderr, "warning: git worktree remove failed for %s: %v\n", name, err)
+		pruneArgs := []string{"worktree", "prune"}
+		pruneOut, _ := runCapture(host, repo, pruneArgs...)
+		logCmd(host, repo, pruneOut, pruneArgs...)
+	} else {
+		logCmd(host, repo, out, args...)
 	}
-	logCmd(host, repo, out, args...)
-	// Force delete the branch regardless of merge status.
+
+	// Step 2: always delete the branch, regardless of step 1's outcome.
 	branchArgs := []string{"branch", "-D", name}
 	out, err = runGit(host, repo, branchArgs...)
 	logCmd(host, repo, out, branchArgs...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: branch delete failed for %s: %v\n", name, err)
 	}
-	return nil
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -285,6 +285,12 @@ func (e *testEnv) rootWorktreeExists(root, name string) bool {
 	return err == nil
 }
 
+func (e *testEnv) branchExists(name string) bool {
+	e.t.Helper()
+	cmd := exec.Command("git", "-C", e.repo, "rev-parse", "--verify", "refs/heads/"+name)
+	return cmd.Run() == nil
+}
+
 func (e *testEnv) addChildWorktree(name string) string {
 	e.t.Helper()
 	wtDir := filepath.Join(e.repo, ".worktrees", name)
@@ -408,6 +414,28 @@ func TestTargetedRm_PushedUnmerged(t *testing.T) {
 	assertContains(t, out, "removed")
 	if env.worktreeExists("in-review") {
 		t.Error("targeted rm should remove pushed unmerged worktree")
+	}
+}
+
+// TestTargetedRm_RegressionOrphanedBranch verifies that wt rm deletes the
+// branch even when the worktree directory has already been removed externally.
+// Previously, git worktree remove would fail on the missing directory and the
+// early return skipped git branch -D, orphaning the branch.
+func TestTargetedRm_RegressionOrphanedBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+	wtDir := env.addWorktree("orphan-test")
+
+	// Simulate external deletion of the worktree directory.
+	os.RemoveAll(wtDir)
+
+	out := env.wt("rm", "orphan-test")
+	assertContains(t, out, "removed")
+	if env.branchExists("orphan-test") {
+		t.Error("branch should be deleted even when worktree directory is already gone")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `WorktreeRemove` and `WorktreeForceRemove` had an early return when `git worktree remove` failed (e.g., directory already deleted), which skipped `git branch -D` entirely — orphaning the local branch permanently.
- Extracted a shared `removeWorktreeAndBranch` that treats worktree deregistration and branch deletion as independent operations. If worktree removal fails, it prunes stale registrations and still deletes the branch.