### PR TITLE
Add create/attach/remote e2e tests, remove dead code

### DIFF
--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -141,24 +141,3 @@ func formatURI(host, repo string, port int) string {
 	}
 	return fmt.Sprintf("%s:%d%s", host, port, path)
 }
-
-func FormatAge(t time.Time, now time.Time) string {
-	if t.IsZero() {
-		return "-"
-	}
-	d := now.Sub(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		return fmt.Sprintf("%dm ago", int(d.Minutes()))
-	case d < 24*time.Hour:
-		return fmt.Sprintf("%dh ago", int(d.Hours()))
-	default:
-		days := int(d.Hours() / 24)
-		if days == 1 {
-			return "1d ago"
-		}
-		return fmt.Sprintf("%dd ago", days)
-	}
-}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -35,16 +34,6 @@ func RepoRoot(host string, dir ...string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(out), nil
-}
-
-// DirExists checks whether a directory exists, locally or over SSH.
-func DirExists(host, path string) bool {
-	if host == "" {
-		info, err := os.Stat(path)
-		return err == nil && info.IsDir()
-	}
-	_, err := ssh.Run(host, fmt.Sprintf("test -d '%s'", path))
-	return err == nil
 }
 
 // UpstreamRef returns the upstream tracking ref for the given branch

--- a/pkg/opencode/session.go
+++ b/pkg/opencode/session.go
@@ -56,16 +56,6 @@ func RemoteServerURL() string {
 	return fmt.Sprintf("http://localhost:%d", TunnelPort())
 }
 
-// CheckHealth verifies that the OpenCode server is reachable.
-func CheckHealth(serverURL string) error {
-	resp, err := httpGet(serverURL + "/global/health")
-	if err != nil {
-		return fmt.Errorf("opencode server not reachable at %s", serverURL)
-	}
-	resp.Body.Close()
-	return nil
-}
-
 // checkHealthFast is a quick probe for use before batch operations.
 func checkHealthFast(serverURL string) error {
 	resp, err := httpGetTimeout(serverURL+"/global/health", 1*time.Second)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -384,6 +387,66 @@ func assertContains(t *testing.T, output, substring string) {
 	if !strings.Contains(output, substring) {
 		t.Errorf("output does not contain %q:\n%s", substring, output)
 	}
+}
+
+// writeStubOpencode creates a stub shell script that replaces the real opencode
+// binary. It handles:
+//   - "opencode serve --port <port>": stays alive until killed; writes PID to $OPENCODE_PIDFILE
+//   - "opencode attach ...": exits 0 immediately
+func writeStubOpencode(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "opencode")
+	script := `#!/bin/sh
+if [ "$1" = "serve" ]; then
+  if [ -n "$OPENCODE_PIDFILE" ]; then
+    echo $$ > "$OPENCODE_PIDFILE"
+  fi
+  trap 'exit 0' TERM
+  while true; do sleep 1; done
+fi
+# attach or anything else — just exit 0
+exit 0
+`
+	if err := os.WriteFile(stub, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// wtCreate runs the wt binary with the stub opencode on PATH. It sets
+// OPENCODE_PIDFILE and kills any serve process in t.Cleanup.
+func (e *testEnv) wtCreate(args ...string) string {
+	e.t.Helper()
+	stubDir := writeStubOpencode(e.t)
+	pidFile := filepath.Join(e.t.TempDir(), "opencode.pid")
+	cmd := exec.Command(wtBinary, args...)
+	cmd.Dir = e.repo
+	cmd.Env = append(os.Environ(),
+		"HOME="+e.rootDir,
+		"WT_REMOTE_HOST=",
+		"WT_OPENCODE_PORT="+e.mockPort,
+		"OPENCODE_PIDFILE="+pidFile,
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		e.t.Fatalf("wt %v: %v\n%s", args, err, out)
+	}
+
+	e.t.Cleanup(func() {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return // no serve process was started
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			return
+		}
+		syscall.Kill(pid, syscall.SIGTERM)
+	})
+
+	return string(out)
 }
 
 // --- Targeted rm tests (always removes) ---
@@ -1301,4 +1364,80 @@ func TestRm_ExtraArgs(t *testing.T) {
 		t.Error("expected non-zero exit code for rm with extra arguments")
 	}
 	assertContains(t, out, "unexpected argument")
+}
+
+// --- Create / attach tests ---
+
+// TestHelp verifies that wt --help prints usage and exits 0.
+func TestHelp(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+	cmd := exec.Command(wtBinary, "--help")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("wt --help failed: %v\n%s", err, out)
+	}
+	assertContains(t, string(out), "worktree session manager")
+}
+
+// TestCreate_NewWorktree verifies that `wt` (no args) creates a new worktree,
+// sets up the branch with upstream tracking, and attaches via the stub opencode.
+func TestCreate_NewWorktree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	out := env.wtCreate()
+	t.Log("output:\n" + out)
+
+	// Output should contain a name matching <repobase>-<7hex>
+	repoBase := filepath.Base(env.repo)
+	nameRe := regexp.MustCompile(regexp.QuoteMeta(repoBase) + `-[0-9a-f]{7}`)
+	match := nameRe.FindString(out)
+	if match == "" {
+		t.Fatalf("output does not contain a worktree name matching %s-<7hex>:\n%s", repoBase, out)
+	}
+
+	// Worktree directory should exist as a sibling of the repo (default root="..")
+	wtDir := filepath.Join(filepath.Dir(env.repo), match)
+	if _, err := os.Stat(wtDir); os.IsNotExist(err) {
+		t.Errorf("worktree directory %s was not created", wtDir)
+	}
+
+	// git worktree list should include the new worktree
+	wtList := gitCmd(t, env.repo, "worktree", "list")
+	assertContains(t, wtList, match)
+
+	// Branch should exist with upstream set
+	upstream, err := exec.Command("git", "-C", env.repo, "for-each-ref",
+		"--format=%(upstream:short)", "refs/heads/"+match).Output()
+	if err != nil {
+		t.Fatalf("failed to query upstream for branch %s: %v", match, err)
+	}
+	upstreamRef := strings.TrimSpace(string(upstream))
+	if upstreamRef == "" {
+		t.Errorf("branch %s has no upstream set", match)
+	}
+}
+
+// TestCreate_AttachExisting verifies that `wt <name>` attaches to an existing
+// worktree (finding its latest session) via the stub opencode.
+func TestCreate_AttachExisting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wtDir := env.addWorktree("test-attach")
+	env.createSession(wtDir)
+
+	out := env.wtCreate("test-attach")
+	t.Log("output:\n" + out)
+
+	assertContains(t, out, "test-attach")
 }

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -1,12 +1,18 @@
 package e2e_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -272,4 +278,138 @@ func TestSSH_Ls_BadHost(t *testing.T) {
 	if !strings.Contains(output, "warning") {
 		t.Error("expected a warning about unreachable remote host in output")
 	}
+}
+
+// TestCreate_Remote verifies the full remote create flow: SSH to localhost,
+// create a worktree on the remote, tunnel to the mock server, and attach.
+// Exercises: ssh.Host, ssh.ResolveRemoteHome, ssh.ToRemotePath, git.RepoRoot(host),
+// git.WorktreeAdd(host), ssh.EnsureTunnel, opencode.EnsureRemoteServer.
+func TestCreate_Remote(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping SSH e2e test in short mode")
+	}
+
+	// Force self-SSH to localhost regardless of WT_REMOTE_HOST.
+	host := "localhost"
+	if out, err := sshRunErr(host, "echo ok"); err != nil {
+		t.Skipf("SSH to %s not available (enable Remote Login for localhost): %v\n%s", host, err, out)
+	}
+
+	// Build a minimal test repo on localhost (same machine).
+	name := fmt.Sprintf("wt-e2e-create-%d-%d", time.Now().UnixNano(), rand.Intn(100000))
+	remoteHome := strings.TrimSpace(sshRun(t, host, `cd "$HOME" && pwd -P`))
+	rootDir := remoteHome + "/" + name
+	repo := rootDir + "/repo"
+
+	sshRun(t, host, "mkdir -p "+rootDir)
+	sshRun(t, host, fmt.Sprintf(`
+		git init --bare --initial-branch=main %s/origin.git &&
+		git clone %s/origin.git %s &&
+		cd %s &&
+		git config user.email 'test@test.com' &&
+		git config user.name 'Test' &&
+		git checkout -b main &&
+		git commit --allow-empty -m 'initial' &&
+		git push origin main
+	`, rootDir, rootDir, repo, repo))
+	t.Cleanup(func() { sshRun(t, host, "rm -rf "+rootDir) })
+
+	// Start a mock OpenCode server on a random port. The tunnel will forward
+	// to this port, and EnsureRemoteServer health-checks through the tunnel,
+	// so it short-circuits without trying to start a real opencode.
+	mockPort, mockURL := startMockOpencode(t)
+	_ = mockURL
+
+	// The stub opencode must be on PATH for the attach call, which execs
+	// "opencode attach ...". Since self-SSH runs on the same machine, the
+	// local PATH override works for both the local and remote sides.
+	stubDir := writeStubOpencode(t)
+	pidFile := filepath.Join(t.TempDir(), "opencode.pid")
+
+	// Run: wt -r <repo-path>
+	// This triggers cmdRemote which:
+	// 1. ssh.Host() → reads WT_REMOTE_HOST
+	// 2. ssh.ResolveRemoteHome(host) → SSHes to resolve $HOME
+	// 3. ssh.ToRemotePath(repoPath, remoteHome) → translates path
+	// 4. git.RepoRoot(host, remotePath) → finds repo root on remote
+	// 5. git.WorktreeAdd(host, ...) → creates worktree on remote
+	// 6. ssh.EnsureTunnel(host, mockPort+1, mockPort) → tunnels
+	// 7. opencode.EnsureRemoteServer(host) → health-checks through tunnel
+	// 8. attach(...) → runs stub opencode
+	cmd := exec.Command(wtBinary, "-r", repo)
+	cmd.Env = append(os.Environ(),
+		"HOME="+remoteHome,
+		"WT_REMOTE_HOST="+host,
+		"WT_OPENCODE_PORT="+strconv.Itoa(mockPort),
+		"OPENCODE_PIDFILE="+pidFile,
+		"PATH="+stubDir+":"+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	output := string(out)
+	t.Logf("wt -r output:\n%s", output)
+
+	t.Cleanup(func() {
+		data, readErr := os.ReadFile(pidFile)
+		if readErr != nil {
+			return
+		}
+		pid, convErr := strconv.Atoi(strings.TrimSpace(string(data)))
+		if convErr != nil {
+			return
+		}
+		syscall.Kill(pid, syscall.SIGTERM)
+	})
+
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("expected exit 0, got %d; output:\n%s", exitErr.ExitCode(), output)
+		} else {
+			t.Fatalf("unexpected error: %v\n%s", err, output)
+		}
+	}
+
+	// Output should contain a worktree name matching <repobase>-<7hex>
+	repoBase := filepath.Base(repo)
+	nameRe := regexp.MustCompile(regexp.QuoteMeta(repoBase) + `-[0-9a-f]{7}`)
+	match := nameRe.FindString(output)
+	if match == "" {
+		t.Fatalf("output does not contain a worktree name matching %s-<7hex>:\n%s", repoBase, output)
+	}
+
+	// Verify the worktree directory was created on the remote
+	repoDir := filepath.Dir(repo)
+	wtDir := repoDir + "/" + match
+	if _, sshErr := sshRunErr(host, fmt.Sprintf("test -d '%s'", wtDir)); sshErr != nil {
+		t.Errorf("worktree directory %s was not created on remote", wtDir)
+	}
+}
+
+// startMockOpencode starts a minimal mock OpenCode server that responds to
+// /global/health, /session, and /session/<id>/message. Returns the port and URL.
+func startMockOpencode(t *testing.T) (int, string) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/global/health", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"healthy": true})
+	})
+	mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]any{})
+	})
+	mux.HandleFunc("/session/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]any{})
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close() })
+
+	_, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	url := "http://" + ln.Addr().String()
+	return port, url
 }


### PR DESCRIPTION
Add e2e tests for the create flow (wt, wt <name>) using a stub opencode binary, and for remote create (wt -r) via self-SSH. Add --help test. Remove dead code: git.DirExists, opencode.CheckHealth, display.FormatAge.

5 files changed, 280 insertions(+), 42 deletions(-)