### PR TITLE
Separate worktree identity from branch state in discovery

### DIFF
--- a/pkg/discover/local.go
+++ b/pkg/discover/local.go
@@ -211,14 +211,19 @@ func parseWorktreeList(porcelain, repo string) []worktree.Entry {
 // the repo's main checkout). Every non-root worktree reported by git worktree
 // list is considered wt-managed — no path-pattern matching needed.
 func matchWorktree(wtPath, branch, repo string) (worktree.Entry, bool) {
-	if branch == "" || wtPath == repo {
+	if wtPath == repo {
 		return worktree.Entry{}, false
 	}
-	return newEntry(branch, wtPath, repo), true
+	return newEntry(wtPath, branch, repo), true
 }
 
-func newEntry(name, dir, repo string) worktree.Entry {
-	e := worktree.Entry{Name: name, Dir: dir, Repo: repo}
+func newEntry(dir, branch, repo string) worktree.Entry {
+	e := worktree.Entry{
+		Name:   filepath.Base(dir),
+		Dir:    dir,
+		Repo:   repo,
+		Branch: branch,
+	}
 	if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
 		e.CreatedAt = info.ModTime()
 	}

--- a/pkg/discover/remote.go
+++ b/pkg/discover/remote.go
@@ -2,6 +2,7 @@ package discover
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 
@@ -25,12 +26,15 @@ process_repo() {
             /^worktree / { wt=$2 }
             /^branch / {
                 br=$2; sub(/^refs\/heads\//, "", br)
-                if (wt != repo) {
+            }
+            /^$/ {
+                if (wt != "" && wt != repo) {
                     cmd = "stat -c %Y \"" wt "/.git\" 2>/dev/null || stat -f %m \"" wt "/.git\" 2>/dev/null || echo 0"
                     cmd | getline ts
                     close(cmd)
                     print wt "\t" br "\t" repo "\t" ts
                 }
+                wt=""; br=""
             }
         '
     fi
@@ -67,11 +71,13 @@ done
 		if len(parts) < 3 {
 			continue
 		}
+		dir := parts[0]
 		e := worktree.Entry{
-			Dir:  parts[0],
-			Name: parts[1],
-			Repo: parts[2],
-			Host: host,
+			Dir:    dir,
+			Name:   path.Base(dir),
+			Repo:   parts[2],
+			Branch: parts[1], // empty if detached
+			Host:   host,
 		}
 		if len(parts) >= 4 {
 			if ts, err := strconv.ParseInt(strings.TrimSpace(parts[3]), 10, 64); err == nil {

--- a/pkg/git/classify.go
+++ b/pkg/git/classify.go
@@ -214,6 +214,12 @@ while IFS=$'\t' read -r dir repo branch; do
         clean=true
     fi
 
+    # Detached worktrees have no branch — skip all ref-dependent logic.
+    if [ -z "$branch" ]; then
+        printf '%s\t%s\t%s\t%s\n' "$clean" "0" "false" "false"
+        continue
+    fi
+
     # Get upstream tracking ref for this branch
     upstream=$(git -C "$repo" for-each-ref --format='%(upstream:short)' "refs/heads/$branch" 2>/dev/null)
     if [ -z "$upstream" ]; then

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -40,25 +40,27 @@ func Pull(host, repo string) error {
 	return nil
 }
 
-// WorktreeRemove removes the worktree directory and force-deletes the branch.
+// WorktreeRemove removes the worktree directory and deletes the branch.
 // wtDir is the worktree's actual path on disk (may be sibling or child layout).
+// branch may be empty for detached worktrees (skips branch deletion).
 // The caller's classification logic has already confirmed safety.
-func WorktreeRemove(host, repo, name, wtDir string) error {
-	removeWorktreeAndBranch(host, repo, name, wtDir, false)
+func WorktreeRemove(host, repo, branch, wtDir string) error {
+	removeWorktreeAndBranch(host, repo, branch, wtDir, false)
 	return nil
 }
 
 // WorktreeForceRemove removes the worktree and branch without safety checks.
 // wtDir is the worktree's actual path on disk (may be sibling or child layout).
-func WorktreeForceRemove(host, repo, name, wtDir string) error {
-	removeWorktreeAndBranch(host, repo, name, wtDir, true)
+// branch may be empty for detached worktrees (skips branch deletion).
+func WorktreeForceRemove(host, repo, branch, wtDir string) error {
+	removeWorktreeAndBranch(host, repo, branch, wtDir, true)
 	return nil
 }
 
 // removeWorktreeAndBranch deregisters the worktree and deletes its branch.
 // The two operations are independent — a missing worktree directory must not
 // prevent the branch from being cleaned up.
-func removeWorktreeAndBranch(host, repo, name, wtDir string, force bool) {
+func removeWorktreeAndBranch(host, repo, branch, wtDir string, force bool) {
 	// Step 1: try to deregister the worktree directory.
 	args := []string{"worktree", "remove", wtDir}
 	if force {
@@ -68,7 +70,7 @@ func removeWorktreeAndBranch(host, repo, name, wtDir string, force bool) {
 	if err != nil {
 		// Directory already gone or other issue — prune stale registrations
 		// so git no longer thinks the branch is checked out.
-		fmt.Fprintf(os.Stderr, "warning: git worktree remove failed for %s: %v\n", name, err)
+		fmt.Fprintf(os.Stderr, "warning: git worktree remove failed for %s: %v\n", wtDir, err)
 		pruneArgs := []string{"worktree", "prune"}
 		pruneOut, _ := runCapture(host, repo, pruneArgs...)
 		logCmd(host, repo, pruneOut, pruneArgs...)
@@ -76,11 +78,13 @@ func removeWorktreeAndBranch(host, repo, name, wtDir string, force bool) {
 		logCmd(host, repo, out, args...)
 	}
 
-	// Step 2: always delete the branch, regardless of step 1's outcome.
-	branchArgs := []string{"branch", "-D", name}
-	out, err = runGit(host, repo, branchArgs...)
-	logCmd(host, repo, out, branchArgs...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: branch delete failed for %s: %v\n", name, err)
+	// Step 2: delete the branch if one exists (detached worktrees have no branch).
+	if branch != "" {
+		branchArgs := []string{"branch", "-D", branch}
+		out, err = runGit(host, repo, branchArgs...)
+		logCmd(host, repo, out, branchArgs...)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: branch delete failed for %s: %v\n", branch, err)
+		}
 	}
 }

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -20,10 +20,11 @@ func WorktreeDir(repo, root, name string) string {
 
 // Entry represents a discovered worktree.
 type Entry struct {
-	Name string // branch/worktree name
-	Dir  string // absolute path on the host where it lives
-	Repo string // repo root path
-	Host string // hostname where the worktree's server runs (empty = local)
+	Name   string // directory basename — the worktree's stable identity
+	Dir    string // absolute path on the host where it lives
+	Repo   string // repo root path
+	Host   string // hostname where the worktree's server runs (empty = local)
+	Branch string // checked-out branch (empty if HEAD is detached)
 	CreatedAt time.Time // worktree creation time (from filesystem)
 	UpdatedAt time.Time // last session activity (from OpenCode)
 	SessionID string    // most recent OpenCode session ID (empty if none)

--- a/rm.go
+++ b/rm.go
@@ -71,10 +71,19 @@ func classifyAll(all []worktree.Entry, pulled pullResult) []string {
 					statuses[re.idx] = "working"
 					continue
 				}
+				if e.Branch == "" {
+					// No branch to classify against upstream; use simple status.
+					batchEntries = append(batchEntries, git.ClassifyEntry{
+						Dir:  e.Dir,
+						Repo: e.Repo,
+					})
+					batchIdxs = append(batchIdxs, re.idx)
+					continue
+				}
 				batchEntries = append(batchEntries, git.ClassifyEntry{
 					Dir:    e.Dir,
 					Repo:   e.Repo,
-					Branch: e.Name,
+					Branch: e.Branch,
 				})
 				batchIdxs = append(batchIdxs, re.idx)
 			}
@@ -123,9 +132,21 @@ func classifyStatus(e worktree.Entry) string {
 	if !git.IsClean(host, e.Dir) {
 		return "dirty"
 	}
-	unique := git.UniqueCommitCount(host, e.Repo, e.Name)
+
+	// Worktrees with no branch (detached HEAD) have no upstream to classify against.
+	if e.Branch == "" {
+		if e.SessionID == "" {
+			return "empty"
+		}
+		if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
+			return "stale"
+		}
+		return "idle"
+	}
+
+	unique := git.UniqueCommitCount(host, e.Repo, e.Branch)
 	if unique > 0 {
-		if git.IsMerged(host, e.Repo, e.Name) {
+		if git.IsMerged(host, e.Repo, e.Branch) {
 			return "merged"
 		}
 		return "committed"
@@ -143,7 +164,7 @@ func classifyStatus(e worktree.Entry) string {
 	// a proper ancestor of upstream (behind, not at the same commit).
 	// Only checked when a session exists — a worktree with no session
 	// never had work to merge.
-	if git.IsBehindUpstream(host, e.Repo, e.Name) {
+	if git.IsBehindUpstream(host, e.Repo, e.Branch) {
 		return "merged"
 	}
 
@@ -160,6 +181,16 @@ func classifyStatus(e worktree.Entry) string {
 func classifyFromResult(e worktree.Entry, clean bool, unique int, merged bool, behind bool) string {
 	if !clean {
 		return "dirty"
+	}
+	// Detached worktrees have no branch — ignore ref-dependent results.
+	if e.Branch == "" {
+		if e.SessionID == "" {
+			return "empty"
+		}
+		if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
+			return "stale"
+		}
+		return "idle"
 	}
 	if unique > 0 {
 		if merged {
@@ -213,7 +244,7 @@ func cmdRmBatch() {
 
 		if isRemovable(status) {
 			host := hostFor(e)
-			if err := git.WorktreeRemove(host, e.Repo, e.Name, e.Dir); err != nil {
+			if err := git.WorktreeRemove(host, e.Repo, e.Branch, e.Dir); err != nil {
 				errMsg = strings.ReplaceAll(strings.TrimSpace(err.Error()), "\n", " ")
 			} else {
 				status = "removed"
@@ -267,7 +298,7 @@ func cmdRmTargeted(name string) {
 		die("worktree %q not found", name)
 	}
 	host := hostFor(entry)
-	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Name, entry.Dir); err != nil {
+	if err := git.WorktreeForceRemove(host, entry.Repo, entry.Branch, entry.Dir); err != nil {
 		die("%v", err)
 	}
 	display.PrintTable([]display.Row{{

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -561,6 +561,53 @@ func TestTargetedRm_RegressionOrphanedBranch(t *testing.T) {
 
 // --- Batch tests ---
 
+// TestLs_RegressionDetachedHead verifies that worktrees with a detached HEAD
+// appear in wt ls. Previously, discovery filtered on branch being non-empty,
+// and detached worktrees have no branch line in git worktree list --porcelain,
+// so they were silently dropped.
+func TestLs_RegressionDetachedHead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wtDir := env.addWorktree("detached-wt")
+	env.commitFile(wtDir, "f.txt", "work", "add file")
+
+	// Detach HEAD by checking out the current commit directly.
+	head := strings.TrimSpace(gitCmd(t, wtDir, "rev-parse", "HEAD"))
+	gitCmd(t, wtDir, "checkout", head)
+
+	out := env.wt("ls")
+	t.Log("output:\n" + out)
+
+	assertContains(t, out, "detached-wt")
+}
+
+// TestTargetedRm_RegressionDetachedHead verifies that wt rm works on a
+// worktree with a detached HEAD — it should remove the worktree directory
+// and skip branch deletion (since there's no branch checked out).
+func TestTargetedRm_RegressionDetachedHead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wtDir := env.addWorktree("detached-rm")
+
+	// Detach HEAD
+	head := strings.TrimSpace(gitCmd(t, wtDir, "rev-parse", "HEAD"))
+	gitCmd(t, wtDir, "checkout", head)
+
+	out := env.wt("rm", "detached-rm")
+	assertContains(t, out, "removed")
+	if env.worktreeExists("detached-rm") {
+		t.Error("detached HEAD worktree should have been removed")
+	}
+}
+
 func TestLs_UnifiedStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")


### PR DESCRIPTION
## Summary

- Worktree discovery conflated display identity with git branch ref in `Entry.Name` — when HEAD was detached (no branch), the worktree was silently dropped from `wt ls`, `wt rm`, and `wt diff`
- `Entry.Name` is now `filepath.Base(Dir)` (the stable worktree identity), and `Entry.Branch` is optional metadata (empty when detached)
- `matchWorktree` filters only on path != repo, not branch state — any non-root worktree is discovered regardless of HEAD state
- Classification and removal check `Branch != ""` before branch-dependent git operations