### PR TITLE
Derive upstream from root branch instead of tracking config

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -25,11 +25,10 @@ Worktrees are created per unit of work and cleaned up separately when the branch
 lands. The root can be overridden with `--root <dir>` (e.g. `--root .worktrees`
 when the repo is `$HOME` and the parent directory is not writable).
 
-The **root branch** is whatever branch the repo root has checked out at worktree
-creation time (typically `main`). Each worktree records `origin/<root-branch>` as
-its merge target. Diff, status, and merge detection all compare the worktree's
-branch against this target. The value is set once at creation and does not change
-if the repo root later checks out a different branch.
+The **root branch** is whatever branch the repo root currently has checked out
+(typically `main`). Diff, status, and merge detection all compare the worktree's
+branch against `origin/<root-branch>`, derived at query time from the repo root's
+HEAD.
 
 A **session** is an OpenCode conversation bound to a worktree directory. Sessions
 persist on the server and carry a title (auto-generated from the first prompt)
@@ -135,8 +134,8 @@ history, and reattaching resumes the session.
 Create or resume a worktree.
 
 - No args: pull the current branch to ensure the worktree starts from the
-  latest remote state. Create a new worktree with `origin/<root-branch>` as its
-  merge target. Attach. Pull again on exit so the exit summary reflects the
+  latest remote state. Create a new worktree branched from the current HEAD.
+  Attach. Pull again on exit so the exit summary reflects the
   latest remote state.
 - With `name`: pull the repo's current branch (best-effort) to keep it fresh
   for future worktree creation and merge detection. Resume
@@ -308,7 +307,7 @@ detected by scanning local `opencode attach` processes.
 
 - The repo root checkout is clean. Worktree creation pulls the current branch,
   so conflicts or uncommitted changes would cause a failure. The checked-out
-  branch becomes the root branch for the new worktree.
+  branch becomes the base for the new worktree's commits.
 - The remote host is reachable via SSH.
 - `opencode` is available on PATH (locally and on the remote host).
 

--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ func cmdDiff(args []string) {
 		fmt.Fprintf(os.Stderr, "warning: pull failed: %v\n", err)
 	}
 
-	stat, err := git.DiffStat(host, entry.Dir)
+	stat, err := git.DiffStat(host, entry.Dir, entry.Repo)
 	if err != nil {
 		die("diff: %v", err)
 	}
@@ -260,7 +260,7 @@ func cmdDiff(args []string) {
 	fmt.Println(stat)
 
 	isTTY := isTerminal()
-	full, err := git.Diff(host, entry.Dir, isTTY)
+	full, err := git.Diff(host, entry.Dir, entry.Repo, isTTY)
 	if err != nil {
 		die("diff: %v", err)
 	}

--- a/pkg/git/classify.go
+++ b/pkg/git/classify.go
@@ -20,7 +20,7 @@ func IsClean(host, dir string) bool {
 // its upstream tracking ref. Returns 0 if the branch has not diverged or has
 // no upstream configured.
 func UniqueCommitCount(host, repo, branch string) int {
-	upstream, err := UpstreamRef(host, repo, branch)
+	upstream, err := UpstreamRef(host, repo)
 	if err != nil {
 		return 0
 	}
@@ -40,7 +40,7 @@ func UniqueCommitCount(host, repo, branch string) int {
 // In all these cases, rev-list sees zero unique commits because the branch
 // has not diverged from the upstream's ancestry graph.
 func IsBehindUpstream(host, repo, branch string) bool {
-	upstream, err := UpstreamRef(host, repo, branch)
+	upstream, err := UpstreamRef(host, repo)
 	if err != nil {
 		return false
 	}
@@ -76,7 +76,7 @@ func IsBehindUpstream(host, repo, branch string) bool {
 // (UniqueCommitCount > 0). A branch with no divergence trivially matches
 // the target tree and would produce a false positive.
 func IsMerged(host, repo, branch string) bool {
-	upstream, err := UpstreamRef(host, repo, branch)
+	upstream, err := UpstreamRef(host, repo)
 	if err != nil {
 		return false
 	}
@@ -220,12 +220,13 @@ while IFS=$'\t' read -r dir repo branch; do
         continue
     fi
 
-    # Get upstream tracking ref for this branch
-    upstream=$(git -C "$repo" for-each-ref --format='%(upstream:short)' "refs/heads/$branch" 2>/dev/null)
-    if [ -z "$upstream" ]; then
+    # Derive upstream from repo root branch (same as local UpstreamRef).
+    root_branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    if [ -z "$root_branch" ] || [ "$root_branch" = "HEAD" ]; then
         printf '%s\t%s\t%s\t%s\n' "$clean" "0" "false" "false"
         continue
     fi
+    upstream="origin/$root_branch"
 
     # UniqueCommitCount
     unique=$(git -C "$repo" rev-list --count "$upstream..$branch" 2>/dev/null) || unique=0

--- a/pkg/git/diff.go
+++ b/pkg/git/diff.go
@@ -8,13 +8,9 @@ import (
 )
 
 // DiffStat returns a --stat summary of changes on this branch vs the merge-base
-// with its upstream tracking ref. Returns "" if there are no changes.
-func DiffStat(host, dir string) (string, error) {
-	branch, err := runGit(host, dir, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		return "", fmt.Errorf("cannot determine branch: %w", err)
-	}
-	upstream, err := UpstreamRef(host, dir, branch)
+// with the root branch's upstream ref. Returns "" if there are no changes.
+func DiffStat(host, dir, repo string) (string, error) {
+	upstream, err := UpstreamRef(host, repo)
 	if err != nil {
 		return "", err
 	}
@@ -34,13 +30,9 @@ func DiffStat(host, dir string) (string, error) {
 }
 
 // Diff returns the full diff of changes on this branch vs the merge-base
-// with its upstream tracking ref. If color is true, ANSI color codes are included.
-func Diff(host, dir string, color bool) (string, error) {
-	branch, err := runGit(host, dir, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		return "", fmt.Errorf("cannot determine branch: %w", err)
-	}
-	upstream, err := UpstreamRef(host, dir, branch)
+// with the root branch's upstream ref. If color is true, ANSI color codes are included.
+func Diff(host, dir, repo string, color bool) (string, error) {
+	upstream, err := UpstreamRef(host, repo)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -36,15 +36,20 @@ func RepoRoot(host string, dir ...string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
-// UpstreamRef returns the upstream tracking ref for the given branch
-// (e.g., "origin/krocodile"). Returns an error if no upstream is configured.
-// Works from any directory in the repo (worktree or root).
-func UpstreamRef(host, dir, branch string) (string, error) {
-	out, err := runGit(host, dir, "for-each-ref", "--format=%(upstream:short)", "refs/heads/"+branch)
-	if err != nil || out == "" {
-		return "", fmt.Errorf("no upstream configured for branch %q\n\nSet it with: git branch --set-upstream-to=origin/<base> %s", branch, branch)
+// UpstreamRef returns the comparison target for worktree branches — always
+// origin/<rootBranch>, where rootBranch is whatever the repo root has checked
+// out (typically "main"). This is independent of any branch's git tracking
+// config, which may be overwritten by git push -u to point at the branch's
+// own remote ref.
+func UpstreamRef(host, repo string) (string, error) {
+	rootBranch, err := runGit(host, repo, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("cannot determine root branch in %s: %w", repo, err)
 	}
-	return out, nil
+	if rootBranch == "" || rootBranch == "HEAD" {
+		return "", fmt.Errorf("cannot determine root branch in %s (detached HEAD?)", repo)
+	}
+	return "origin/" + rootBranch, nil
 }
 
 // runGit runs a git command in the given directory. If host is empty, runs locally.

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -5,9 +5,9 @@ import (
 	"os"
 )
 
-// WorktreeAdd creates a new worktree at wtDir on branch <name>. Sets the new
-// branch's upstream tracking ref to origin/<root-branch>, where root-branch is
-// whatever the repo root has checked out.
+// WorktreeAdd creates a new worktree at wtDir on branch <name>. No tracking
+// ref is set — UpstreamRef derives the comparison target from the repo root
+// at query time.
 func WorktreeAdd(host, repo, name, wtDir string) error {
 	args := []string{"worktree", "add", wtDir, "-b", name}
 	out, err := runCapture(host, repo, args...)
@@ -16,15 +16,6 @@ func WorktreeAdd(host, repo, name, wtDir string) error {
 	}
 	logCmd(host, repo, out, args...)
 
-	// Determine the root branch (what the repo root has checked out)
-	rootBranch, err := runGit(host, repo, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		return fmt.Errorf("cannot determine root branch: %w", err)
-	}
-	// Set upstream so diff/ls know what to compare against
-	if _, err := runGit(host, repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name); err != nil {
-		return fmt.Errorf("cannot set upstream for %s: %w", name, err)
-	}
 	return nil
 }
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -96,9 +96,6 @@ func (e *testEnv) addWorktree(name string) string {
 	// New default layout: <parent>/<name> (root="..")
 	wtDir := filepath.Join(filepath.Dir(e.repo), name)
 	gitCmd(e.t, e.repo, "worktree", "add", wtDir, "-b", name)
-	// Set upstream tracking to match WorktreeAdd behavior.
-	rootBranch := strings.TrimSpace(gitCmd(e.t, e.repo, "rev-parse", "--abbrev-ref", "HEAD"))
-	gitCmd(e.t, e.repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name)
 	return wtDir
 }
 
@@ -108,8 +105,6 @@ func (e *testEnv) addLegacySiblingWorktree(name string) string {
 	e.t.Helper()
 	wtDir := filepath.Join(filepath.Dir(e.repo), filepath.Base(e.repo)+"-"+name)
 	gitCmd(e.t, e.repo, "worktree", "add", wtDir, "-b", name)
-	rootBranch := strings.TrimSpace(gitCmd(e.t, e.repo, "rev-parse", "--abbrev-ref", "HEAD"))
-	gitCmd(e.t, e.repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name)
 	return wtDir
 }
 
@@ -355,8 +350,6 @@ func (e *testEnv) addChildWorktree(name string) string {
 	e.t.Helper()
 	wtDir := filepath.Join(e.repo, ".worktrees", name)
 	gitCmd(e.t, e.repo, "worktree", "add", wtDir, "-b", name)
-	rootBranch := strings.TrimSpace(gitCmd(e.t, e.repo, "rev-parse", "--abbrev-ref", "HEAD"))
-	gitCmd(e.t, e.repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name)
 	return wtDir
 }
 
@@ -364,8 +357,6 @@ func (e *testEnv) addRootWorktree(root, name string) string {
 	e.t.Helper()
 	wtDir := filepath.Join(e.repo, root, name)
 	gitCmd(e.t, e.repo, "worktree", "add", wtDir, "-b", name)
-	rootBranch := strings.TrimSpace(gitCmd(e.t, e.repo, "rev-parse", "--abbrev-ref", "HEAD"))
-	gitCmd(e.t, e.repo, "branch", "--set-upstream-to", "origin/"+rootBranch, name)
 	return wtDir
 }
 
@@ -661,6 +652,87 @@ func TestLs_UnifiedStatus(t *testing.T) {
 	assertContains(t, out, "dirty")
 	assertContains(t, out, "batch-unpushed")
 	assertContains(t, out, "committed")
+}
+
+// TestLs_RegressionPushDashU reproduces the bug where `git push -u` overwrites
+// the branch's tracking config from origin/main to origin/<branch>. After the
+// PR merges and the remote branch is deleted (prune), the stale tracking ref
+// broke merge detection — the worktree was misclassified as idle instead of
+// merged.
+func TestLs_RegressionPushDashU(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	// Create a branch, commit, and push with -u (overwrites tracking config)
+	wt := env.addWorktree("push-u-branch")
+	env.commitFile(wt, "feature.txt", "done", "add feature")
+	gitCmd(t, env.repo, "push", "-u", "origin", "push-u-branch")
+	env.createIdleSession(wt)
+
+	// Squash-merge into main, then prune the remote branch
+	env.squashMergeToMain("push-u-branch")
+	gitCmd(t, env.repo, "push", "origin", "--delete", "push-u-branch")
+	gitCmd(t, env.repo, "fetch", "--prune")
+
+	out := env.wt("ls")
+	t.Log("output:\n" + out)
+
+	if !strings.Contains(out, "push-u-branch") || !strings.Contains(out, "merged *") {
+		t.Error("worktree pushed with -u should still be detected as merged after remote branch deletion")
+	}
+}
+
+// TestLs_RegressionPushDashUNoFF reproduces the push -u bug for --no-ff merges.
+// When unique commits = 0 (branch is ancestor of upstream), IsBehindUpstream
+// must still derive the target from the root branch, not the stale tracking ref.
+func TestLs_RegressionPushDashUNoFF(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wt := env.addWorktree("push-u-noff")
+	env.commitFile(wt, "f.txt", "done", "feature")
+	gitCmd(t, env.repo, "push", "-u", "origin", "push-u-noff")
+	env.createIdleSession(wt)
+
+	// --no-ff merge: branch commits become ancestors of upstream
+	env.mergeToMain("push-u-noff")
+	gitCmd(t, env.repo, "push", "origin", "--delete", "push-u-noff")
+	gitCmd(t, env.repo, "fetch", "--prune")
+
+	out := env.wt("ls")
+	t.Log("output:\n" + out)
+
+	if !strings.Contains(out, "push-u-noff") || !strings.Contains(out, "merged *") {
+		t.Error("no-ff merged worktree pushed with -u should be detected as merged after remote branch deletion")
+	}
+}
+
+// TestDiff_RegressionPushDashU verifies that wt diff works correctly when
+// git push -u has overwritten the branch's tracking config and the remote
+// branch has been deleted.
+func TestDiff_RegressionPushDashU(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wt := env.addWorktree("diff-push-u")
+	env.commitFile(wt, "feature.txt", "content", "add feature")
+	gitCmd(t, env.repo, "push", "-u", "origin", "diff-push-u")
+	gitCmd(t, env.repo, "push", "origin", "--delete", "diff-push-u")
+	gitCmd(t, env.repo, "fetch", "--prune")
+
+	out := env.wt("diff", "diff-push-u")
+	t.Log("output:\n" + out)
+
+	assertContains(t, out, "feature.txt")
 }
 
 // TestLs_RegressionPrunedTrackingRef verifies that squash merge detection
@@ -981,10 +1053,9 @@ func TestDiff_NotFound(t *testing.T) {
 	assertContains(t, out, "not found")
 }
 
-// TestDiff_NonDefaultBranch verifies that wt diff uses the upstream tracking
-// ref, not the repo's default branch. Reproduces the bug where a worktree
-// branched from a non-default branch (e.g., krocodile) would diff against
-// origin/main instead of origin/<actual-base>.
+// TestDiff_NonDefaultBranch verifies that wt diff uses the root worktree's
+// branch as the comparison target. When the repo root is checked out to
+// "krocodile", diff should compare against origin/krocodile, not origin/main.
 func TestDiff_NonDefaultBranch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
@@ -1013,7 +1084,8 @@ func TestDiff_NonDefaultBranch(t *testing.T) {
 }
 
 // TestLs_NonDefaultBranch verifies that wt ls correctly classifies worktrees
-// branched from a non-default branch using the upstream tracking ref.
+// when the repo root is on a non-default branch. Merge detection derives the
+// comparison target from the root worktree's branch (origin/krocodile here).
 func TestLs_NonDefaultBranch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e test")
@@ -1045,12 +1117,10 @@ func TestLs_NonDefaultBranch(t *testing.T) {
 	if !strings.Contains(out, "kroc-merged") {
 		t.Error("worktree should appear in ls output")
 	}
-	// The branch is merged into origin/krocodile (its upstream), so it must NOT
-	// be classified as "committed". With the old DefaultBranch code, it would
-	// show as "committed" because origin/main doesn't contain the krocodile
-	// commits.
+	// The branch is merged into origin/krocodile (the root branch), so it must
+	// NOT be classified as "committed".
 	if strings.Contains(out, "committed") {
-		t.Error("worktree should not be classified as committed; upstream tracking ref is wrong")
+		t.Error("worktree should not be classified as committed; root branch derivation is wrong")
 	}
 }
 
@@ -1459,15 +1529,10 @@ func TestCreate_NewWorktree(t *testing.T) {
 	wtList := gitCmd(t, env.repo, "worktree", "list")
 	assertContains(t, wtList, match)
 
-	// Branch should exist with upstream set
-	upstream, err := exec.Command("git", "-C", env.repo, "for-each-ref",
-		"--format=%(upstream:short)", "refs/heads/"+match).Output()
-	if err != nil {
-		t.Fatalf("failed to query upstream for branch %s: %v", match, err)
-	}
-	upstreamRef := strings.TrimSpace(string(upstream))
-	if upstreamRef == "" {
-		t.Errorf("branch %s has no upstream set", match)
+	// Branch should exist
+	branchList := gitCmd(t, env.repo, "branch", "--list", match)
+	if strings.TrimSpace(branchList) == "" {
+		t.Errorf("branch %s was not created", match)
 	}
 }
 

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -74,10 +74,8 @@ func (e *sshTestEnv) addWorktree(name string) string {
 	repoDir := filepath.Dir(e.repo)
 	wtDir := repoDir + "/" + repoBase + "-" + name
 	sshRun(e.t, e.host, fmt.Sprintf(
-		"cd %s && git worktree add %s -b %s && "+
-			"root=$(git rev-parse --abbrev-ref HEAD) && "+
-			"git branch --set-upstream-to=origin/$root %s",
-		e.repo, wtDir, name, name))
+		"cd %s && git worktree add %s -b %s",
+		e.repo, wtDir, name))
 	return wtDir
 }
 


### PR DESCRIPTION
## Summary

- **Fix**: `git push -u` overwrites a branch's tracking ref from `origin/main` to `origin/<branch>`. After the PR merges and the remote branch is deleted, the stale ref silently broke all merge detection — worktrees were misclassified as empty/idle instead of merged.
- **Change**: `UpstreamRef` now derives the comparison target at classify time from the repo root's checked-out branch (`origin/<rootBranch>`), making it immune to `git push -u`. `WorktreeAdd` no longer sets `--set-upstream-to`.
- **Tests**: `TestLs_RegressionPushDashU` (squash merge), `TestLs_RegressionPushDashUNoFF` (no-ff merge), `TestDiff_RegressionPushDashU` (diff path) reproduce the exact bug across all three affected code paths.
- **Design**: Updated `docs/designs/wt.md` to reflect dynamic root branch derivation.