### PR TITLE
Derive dirty status from diff to eliminate dirty-but-empty-diff bug

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -215,7 +215,8 @@ is not touched.
 Show the changes on a worktree's branch. Pulls the repo's current branch
 (best-effort) so the diff is computed against the latest remote state. Computes
 the merge-base between `origin/<root-branch>` and HEAD, then diffs against it,
-capturing both committed and uncommitted changes.
+capturing both committed and uncommitted changes. Untracked files are included
+as new-file diffs.
 
 Output: `--stat` summary printed directly (stays in scrollback), then the full
 diff piped through `less -R` when stdout is a terminal. When piped (e.g., to an
@@ -278,7 +279,7 @@ removed by `wt rm`.
 |--------|---------|
 | `attached` | TUI client connected |
 | `working` | Agent streaming (last assistant message incomplete) |
-| `dirty` | Uncommitted changes in working tree |
+| `dirty` | Visible changes in diff not accounted for by unmerged commits |
 | `merged *` | Changes incorporated into `origin/<root-branch>` |
 | `committed` | Unique commits not yet in `origin/<root-branch>` |
 | `empty *` | No session was ever created |
@@ -287,14 +288,17 @@ removed by `wt rm`.
 
 Session states (`attached`, `working`) take priority — the worktree is in active
 use. Git states (`dirty`, `merged`, `committed`) take priority next — they
-describe the safety of the work. `merged` covers both detection paths: unique
-commits detected as landed (three-phase), and zero unique commits with the branch
-behind the target (behind-target check). Session lifecycle states (`empty`,
-`stale`, `idle`) apply when the working tree is clean and the branch has no
-unique commits. A worktree with no session is `empty` regardless of the branch's
-position relative to the target — it never had work to merge. A worktree with a
-session whose branch is behind the target is `merged` — the work landed via a
-merge that made the branch's commits reachable from the target. Attachment is detected by scanning local `opencode attach` processes. Orphaned attach processes (ppid == 1, reparented to init/launchd after the parent `wt` process died) are killed and excluded — this prevents phantom "attached" status on dead sessions.
+describe the safety of the work. The diff (merge-base comparison + untracked
+files) is the single gate: if the diff is empty, the worktree cannot be dirty.
+If the diff is non-empty with no unique commits, the changes must be uncommitted
+→ dirty. `merged` covers both detection paths: unique commits detected as landed
+(three-phase), and zero unique commits with the branch behind the target
+(behind-target check). Session lifecycle states (`empty`, `stale`, `idle`) apply
+when the diff is empty and the branch has no unique commits. A worktree with no
+session is `empty` regardless of the branch's position relative to the target —
+it never had work to merge. A worktree with a session whose branch is behind the
+target is `merged` — the work landed via a merge that made the branch's commits
+reachable from the target. Attachment is detected by scanning local `opencode attach` processes. Orphaned attach processes (ppid == 1, reparented to init/launchd after the parent `wt` process died) are killed and excluded — this prevents phantom "attached" status on dead sessions.
 
 ## Reconnection
 

--- a/pkg/git/classify.go
+++ b/pkg/git/classify.go
@@ -10,11 +10,7 @@ import (
 	"github.com/ellistarn/wt/pkg/ssh"
 )
 
-// IsClean returns true if the worktree has no modified, staged, or untracked files.
-func IsClean(host, dir string) bool {
-	out, err := runGit(host, dir, "status", "--porcelain")
-	return err == nil && out == ""
-}
+
 
 // UniqueCommitCount returns the number of commits on branch that are not on
 // its upstream tracking ref. Returns 0 if the branch has not diverged or has
@@ -179,15 +175,21 @@ type ClassifyEntry struct {
 
 // ClassifyResult holds the git classification for a single worktree.
 type ClassifyResult struct {
-	Clean  bool // no modified, staged, or untracked files
-	Unique int  // commits on branch not on its upstream
-	Merged bool // branch changes incorporated into its upstream
-	Behind bool // branch is a proper ancestor of its upstream (rebase merge)
+	HasDiff bool // visible changes: tracked modifications vs merge-base OR untracked files
+	Unique  int  // commits on branch not on its upstream
+	Merged  bool // branch changes incorporated into its upstream
+	Behind  bool // branch is a proper ancestor of its upstream (rebase merge)
+	HasUncommitted bool // uncommitted changes (tracked diff vs HEAD or untracked files)
 }
 
 // ClassifyBatch classifies multiple remote worktrees in a single SSH call.
-// Replicates the logic of IsClean + UniqueCommitCount + IsMerged but runs
-// all git commands on the remote host in one round-trip.
+// Computes HasDiff (merge-base diff + untracked), UniqueCommitCount, IsMerged,
+// IsBehindUpstream, and HasUncommitted in one round-trip.
+//
+// SYNC: The shell script mirrors the logic of HasDiff, HasUncommittedChanges,
+// UniqueCommitCount, IsMerged, and IsBehindUpstream. Changes to any of those
+// functions must be reflected here.
+//
 // Returns an error if the SSH call fails entirely.
 func ClassifyBatch(host string, entries []ClassifyEntry) ([]ClassifyResult, error) {
 	if len(entries) == 0 {
@@ -206,27 +208,44 @@ set -eu
 while IFS=$'\t' read -r dir repo branch; do
     [ -z "$dir" ] && continue
 
-    # IsClean
-    status=$(git -C "$dir" status --porcelain 2>/dev/null) || status=""
-    if [ -n "$status" ]; then
-        clean=false
-    else
-        clean=true
+    # Derive upstream from repo root branch (same as local UpstreamRef).
+    root_branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null) || root_branch=""
+    upstream=""
+    if [ -n "$root_branch" ] && [ "$root_branch" != "HEAD" ]; then
+        upstream="origin/$root_branch"
+    fi
+
+    # HasDiff: merge-base diff + untracked files
+    has_diff=false
+    if [ -n "$upstream" ]; then
+        mb=$(git -C "$dir" merge-base "$upstream" HEAD 2>/dev/null) || mb=""
+        if [ -n "$mb" ]; then
+            git -C "$dir" diff --quiet "$mb" 2>/dev/null || has_diff=true
+        fi
+    fi
+    if [ "$has_diff" = "false" ]; then
+        untracked=$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null | head -1)
+        [ -n "$untracked" ] && has_diff=true
+    fi
+
+    # HasUncommitted: diff vs HEAD + untracked files
+    has_uncommitted=false
+    git -C "$dir" diff --quiet HEAD 2>/dev/null || has_uncommitted=true
+    if [ "$has_uncommitted" = "false" ]; then
+        untracked=$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null | head -1)
+        [ -n "$untracked" ] && has_uncommitted=true
     fi
 
     # Detached worktrees have no branch — skip all ref-dependent logic.
     if [ -z "$branch" ]; then
-        printf '%s\t%s\t%s\t%s\n' "$clean" "0" "false" "false"
+        printf '%s\t%s\t%s\t%s\t%s\n' "$has_diff" "0" "false" "false" "$has_uncommitted"
         continue
     fi
 
-    # Derive upstream from repo root branch (same as local UpstreamRef).
-    root_branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null)
-    if [ -z "$root_branch" ] || [ "$root_branch" = "HEAD" ]; then
-        printf '%s\t%s\t%s\t%s\n' "$clean" "0" "false" "false"
+    if [ -z "$upstream" ]; then
+        printf '%s\t%s\t%s\t%s\t%s\n' "$has_diff" "0" "false" "false" "$has_uncommitted"
         continue
     fi
-    upstream="origin/$root_branch"
 
     # UniqueCommitCount
     unique=$(git -C "$repo" rev-list --count "$upstream..$branch" 2>/dev/null) || unique=0
@@ -270,7 +289,7 @@ while IFS=$'\t' read -r dir repo branch; do
         fi
     fi
 
-    printf '%s\t%s\t%s\t%s\n' "$clean" "$unique" "$merged" "$behind"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$has_diff" "$unique" "$merged" "$behind" "$has_uncommitted"
 done << 'ENTRIES'
 ` + heredoc.String() + `ENTRIES
 `
@@ -285,15 +304,18 @@ done << 'ENTRIES'
 		if i >= len(entries) {
 			break
 		}
-		parts := strings.SplitN(line, "\t", 4)
+		parts := strings.SplitN(line, "\t", 5)
 		if len(parts) < 3 {
 			continue
 		}
-		results[i].Clean = parts[0] == "true"
+		results[i].HasDiff = parts[0] == "true"
 		results[i].Unique, _ = strconv.Atoi(parts[1])
 		results[i].Merged = parts[2] == "true"
 		if len(parts) >= 4 {
 			results[i].Behind = parts[3] == "true"
+		}
+		if len(parts) >= 5 {
+			results[i].HasUncommitted = parts[4] == "true"
 		}
 	}
 	return results, nil

--- a/pkg/git/diff.go
+++ b/pkg/git/diff.go
@@ -2,13 +2,15 @@ package git
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/ellistarn/wt/pkg/ssh"
 )
 
 // DiffStat returns a --stat summary of changes on this branch vs the merge-base
-// with the root branch's upstream ref. Returns "" if there are no changes.
+// with the root branch's upstream ref. Includes untracked files. Returns "" if
+// there are no changes.
 func DiffStat(host, dir, repo string) (string, error) {
 	upstream, err := UpstreamRef(host, repo)
 	if err != nil {
@@ -16,8 +18,24 @@ func DiffStat(host, dir, repo string) (string, error) {
 	}
 	if host != "" {
 		script := fmt.Sprintf(
-			`mb=$(git -C '%s' merge-base '%s' HEAD) && git -C '%s' diff --stat "$mb"`,
-			dir, upstream, dir,
+			`mb=$(git -C '%s' merge-base '%s' HEAD) || exit 1
+tracked=$(git -C '%s' diff --stat "$mb")
+untracked=""
+git -C '%s' ls-files --others --exclude-standard | while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    line=$(cd '%s' && git diff --stat --no-index -- /dev/null "$f" 2>/dev/null | head -1) || true
+    [ -n "$line" ] && printf '%%s\n' "$line"
+done > /tmp/wt_untracked_stat_$$
+untracked=$(cat /tmp/wt_untracked_stat_$$ 2>/dev/null)
+rm -f /tmp/wt_untracked_stat_$$
+if [ -n "$tracked" ] && [ -n "$untracked" ]; then
+    printf '%%s\n%%s\n' "$tracked" "$untracked"
+elif [ -n "$tracked" ]; then
+    printf '%%s\n' "$tracked"
+elif [ -n "$untracked" ]; then
+    printf '%%s\n' "$untracked"
+fi`,
+			dir, upstream, dir, dir, dir,
 		)
 		out, err := ssh.Run(host, script)
 		return strings.TrimSpace(out), err
@@ -26,11 +44,29 @@ func DiffStat(host, dir, repo string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("merge-base: %w", err)
 	}
-	return runGit("", dir, "diff", "--stat", mb)
+	tracked, _ := runGit("", dir, "diff", "--stat", mb)
+
+	// Append untracked file stats
+	untracked := untrackedFiles("", dir)
+	if len(untracked) == 0 {
+		return tracked, nil
+	}
+	var parts []string
+	if tracked != "" {
+		parts = append(parts, tracked)
+	}
+	for _, f := range untracked {
+		line := diffNoIndexStat(dir, f)
+		if line != "" {
+			parts = append(parts, line)
+		}
+	}
+	return strings.Join(parts, "\n"), nil
 }
 
 // Diff returns the full diff of changes on this branch vs the merge-base
-// with the root branch's upstream ref. If color is true, ANSI color codes are included.
+// with the root branch's upstream ref. Includes untracked files as new file
+// diffs. If color is true, ANSI color codes are included.
 func Diff(host, dir, repo string, color bool) (string, error) {
 	upstream, err := UpstreamRef(host, repo)
 	if err != nil {
@@ -42,8 +78,13 @@ func Diff(host, dir, repo string, color bool) (string, error) {
 	}
 	if host != "" {
 		script := fmt.Sprintf(
-			`mb=$(git -C '%s' merge-base '%s' HEAD) && git -C '%s' diff '%s' "$mb"`,
-			dir, upstream, dir, colorFlag,
+			`mb=$(git -C '%s' merge-base '%s' HEAD) || exit 1
+git -C '%s' diff '%s' "$mb"
+git -C '%s' ls-files --others --exclude-standard | while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    (cd '%s' && git diff '%s' --no-index -- /dev/null "$f" 2>/dev/null) || true
+done`,
+			dir, upstream, dir, colorFlag, dir, dir, colorFlag,
 		)
 		out, err := ssh.Run(host, script)
 		return strings.TrimSpace(out), err
@@ -52,5 +93,90 @@ func Diff(host, dir, repo string, color bool) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("merge-base: %w", err)
 	}
-	return runGit("", dir, "diff", colorFlag, mb)
+	tracked, _ := runGit("", dir, "diff", colorFlag, mb)
+
+	// Append untracked file diffs
+	untracked := untrackedFiles("", dir)
+	if len(untracked) == 0 {
+		return tracked, nil
+	}
+	var parts []string
+	if tracked != "" {
+		parts = append(parts, tracked)
+	}
+	for _, f := range untracked {
+		d := diffNoIndex(dir, f, color)
+		if d != "" {
+			parts = append(parts, d)
+		}
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+// HasDiff reports whether the worktree has any visible changes — tracked
+// modifications relative to the merge-base OR untracked files. This is the
+// single source of truth for "are there changes worth showing/protecting."
+// It uses the same signals as DiffStat: merge-base diff + untracked files.
+func HasDiff(host, dir, repo string) bool {
+	upstream, err := UpstreamRef(host, repo)
+	if err != nil {
+		// Can't determine upstream; conservatively check for untracked files.
+		return len(untrackedFiles(host, dir)) > 0
+	}
+	mb, err := runGit(host, dir, "merge-base", upstream, "HEAD")
+	if err != nil {
+		return len(untrackedFiles(host, dir)) > 0
+	}
+	// Use --quiet for efficiency: exits 1 if differences exist.
+	_, err = runGit(host, dir, "diff", "--quiet", mb)
+	if err != nil {
+		return true // tracked changes exist
+	}
+	return len(untrackedFiles(host, dir)) > 0
+}
+
+// HasUncommittedChanges reports whether the worktree has modifications not
+// yet committed — tracked file changes relative to HEAD or untracked files.
+// Used as a safety check when a merged branch still shows a diff (to
+// distinguish squash-merge artifacts from new uncommitted work).
+func HasUncommittedChanges(host, dir string) bool {
+	// git diff --quiet HEAD exits 1 if working tree differs from HEAD.
+	_, err := runGit(host, dir, "diff", "--quiet", "HEAD")
+	if err != nil {
+		return true
+	}
+	return len(untrackedFiles(host, dir)) > 0
+}
+
+// untrackedFiles returns untracked file paths relative to the worktree root.
+func untrackedFiles(host, dir string) []string {
+	out, err := runGit(host, dir, "ls-files", "--others", "--exclude-standard")
+	if err != nil || out == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
+}
+
+// diffNoIndexStat returns the first line of --stat output for an untracked file.
+func diffNoIndexStat(dir, file string) string {
+	cmd := exec.Command("git", "diff", "--stat", "--no-index", "--", "/dev/null", file)
+	cmd.Dir = dir
+	out, _ := cmd.Output() // exit code 1 is expected (differences found)
+	lines := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)
+	if len(lines) > 0 && lines[0] != "" {
+		return lines[0]
+	}
+	return ""
+}
+
+// diffNoIndex returns a full unified diff for an untracked file (shown as new).
+func diffNoIndex(dir, file string, color bool) string {
+	colorFlag := "--color=never"
+	if color {
+		colorFlag = "--color=always"
+	}
+	cmd := exec.Command("git", "diff", colorFlag, "--no-index", "--", "/dev/null", file)
+	cmd.Dir = dir
+	out, _ := cmd.Output() // exit code 1 is expected (differences found)
+	return strings.TrimSpace(string(out))
 }

--- a/rm.go
+++ b/rm.go
@@ -126,12 +126,13 @@ func classifyRemoteEntries(host string, entries []remoteEntry, all []worktree.En
 	}
 	for j, r := range results {
 		idx := batchIdxs[j]
-		statuses[idx] = classifyFromResult(all[idx], r.Clean, r.Unique, r.Merged, r.Behind)
+		statuses[idx] = classifyFromResult(all[idx], r)
 	}
 }
 
 // classifyStatus returns the single highest-priority status for a worktree.
-// Priority: attached > working > dirty > merged/committed > empty > merged(behind) > stale > idle.
+// Priority: attached > working > dirty > committed > merged > empty > stale > idle.
+// Uses HasDiff as the single gate: no diff = no dirty.
 func classifyStatus(e worktree.Entry) string {
 	// Session states — active use takes priority
 	if e.Attached {
@@ -141,16 +142,31 @@ func classifyStatus(e worktree.Entry) string {
 		return "working"
 	}
 
-	// Git states — data safety
 	host := hostFor(e)
-	if !git.IsClean(host, e.Dir) {
-		return "dirty"
-	}
+	hasDiff := git.HasDiff(host, e.Dir, e.Repo)
 
-	// Worktrees with no branch (detached HEAD) have no upstream to classify against.
-	if e.Branch == "" {
+	if !hasDiff {
+		// No visible changes — cannot be dirty.
+		if e.Branch == "" {
+			if e.SessionID == "" {
+				return "empty"
+			}
+			if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
+				return "stale"
+			}
+			return "idle"
+		}
+		unique := git.UniqueCommitCount(host, e.Repo, e.Branch)
+		if unique > 0 && git.IsMerged(host, e.Repo, e.Branch) {
+			return "merged"
+		}
+		// Session check before behind: a worktree with no session never had
+		// work to merge, so "behind upstream" is irrelevant.
 		if e.SessionID == "" {
 			return "empty"
+		}
+		if unique == 0 && git.IsBehindUpstream(host, e.Repo, e.Branch) {
+			return "merged"
 		}
 		if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
 			return "stale"
@@ -158,70 +174,72 @@ func classifyStatus(e worktree.Entry) string {
 		return "idle"
 	}
 
+	// Has visible changes in diff.
+	if e.Branch == "" {
+		return "dirty"
+	}
 	unique := git.UniqueCommitCount(host, e.Repo, e.Branch)
-	if unique > 0 {
-		if git.IsMerged(host, e.Repo, e.Branch) {
-			return "merged"
+	if unique == 0 {
+		return "dirty" // changes with no commits = must be uncommitted
+	}
+	if git.IsMerged(host, e.Repo, e.Branch) {
+		// Branch is merged but diff is non-empty. Could be squash-merge
+		// artifact or new uncommitted work. Check to protect from auto-removal.
+		if git.HasUncommittedChanges(host, e.Dir) {
+			return "dirty"
 		}
-		return "committed"
-	}
-
-	// Session lifecycle — no unique commits, clean tree
-	if e.SessionID == "" {
-		return "empty"
-	}
-
-	// Merged with zero unique commits: the branch's commits are reachable
-	// from upstream (regular merge commit, fast-forward, or local rebase).
-	// rev-list sees zero unique commits because the branch hasn't diverged
-	// from upstream's ancestry graph. Detect by checking if the branch is
-	// a proper ancestor of upstream (behind, not at the same commit).
-	// Only checked when a session exists — a worktree with no session
-	// never had work to merge.
-	if git.IsBehindUpstream(host, e.Repo, e.Branch) {
 		return "merged"
 	}
-
-	if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
-		return "stale"
-	}
-	return "idle"
+	return "committed"
 }
 
 // classifyFromResult classifies a worktree using pre-computed git results
 // (from a batch SSH call) instead of making individual git calls.
 // Unlike classifyStatus, this does NOT check Attached or working status —
 // callers must handle those cases before calling this function.
-func classifyFromResult(e worktree.Entry, clean bool, unique int, merged bool, behind bool) string {
-	if !clean {
-		return "dirty"
-	}
-	// Detached worktrees have no branch — ignore ref-dependent results.
-	if e.Branch == "" {
+func classifyFromResult(e worktree.Entry, r git.ClassifyResult) string {
+	if !r.HasDiff {
+		// No visible changes — cannot be dirty.
+		if e.Branch == "" {
+			if e.SessionID == "" {
+				return "empty"
+			}
+			if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
+				return "stale"
+			}
+			return "idle"
+		}
+		if r.Unique > 0 && r.Merged {
+			return "merged"
+		}
+		// Session check before behind: a worktree with no session never had
+		// work to merge, so "behind upstream" is irrelevant.
 		if e.SessionID == "" {
 			return "empty"
+		}
+		if r.Unique == 0 && r.Behind {
+			return "merged"
 		}
 		if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
 			return "stale"
 		}
 		return "idle"
 	}
-	if unique > 0 {
-		if merged {
-			return "merged"
+
+	// Has visible changes in diff.
+	if e.Branch == "" {
+		return "dirty"
+	}
+	if r.Unique == 0 {
+		return "dirty"
+	}
+	if r.Merged {
+		if r.HasUncommitted {
+			return "dirty"
 		}
-		return "committed"
-	}
-	if e.SessionID == "" {
-		return "empty"
-	}
-	if behind {
 		return "merged"
 	}
-	if !e.UpdatedAt.IsZero() && time.Since(e.UpdatedAt) > opencode.StaleThreshold {
-		return "stale"
-	}
-	return "idle"
+	return "committed"
 }
 
 // isRemovable returns true if a status indicates the worktree is safe to remove.

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -654,6 +654,41 @@ func TestLs_UnifiedStatus(t *testing.T) {
 	assertContains(t, out, "committed")
 }
 
+// TestLs_MergedButDirty verifies that a squash-merged branch with new
+// uncommitted changes after the merge is classified as "dirty" (not "merged").
+// This is a data-loss protection: "merged" worktrees are auto-removable, so
+// new uncommitted work must override the merged classification.
+func TestLs_MergedButDirty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	// Create branch, commit, push, squash-merge into main
+	wt := env.addWorktree("merged-dirty")
+	env.commitFile(wt, "feature.txt", "done", "feature")
+	env.push("merged-dirty")
+	env.createIdleSession(wt)
+	env.squashMergeToMain("merged-dirty")
+	gitCmd(t, env.repo, "checkout", "main")
+
+	// Now add new uncommitted work in the worktree AFTER the merge
+	os.WriteFile(filepath.Join(wt, "new-work.txt"), []byte("new stuff"), 0644)
+
+	out := env.wt("ls")
+	t.Log("output:\n" + out)
+
+	// Must be "dirty" not "merged" — protects from auto-removal
+	if !strings.Contains(out, "merged-dirty") {
+		t.Fatal("worktree should appear in ls output")
+	}
+	if strings.Contains(out, "merged") && !strings.Contains(out, "dirty") {
+		t.Error("worktree with uncommitted changes after merge should be 'dirty', not 'merged'")
+	}
+	assertContains(t, out, "dirty")
+}
+
 // TestLs_RegressionPushDashU reproduces the bug where `git push -u` overwrites
 // the branch's tracking config from origin/main to origin/<branch>. After the
 // PR merges and the remote branch is deleted (prune), the stale tracking ref
@@ -1035,6 +1070,50 @@ func TestDiff_NoChanges(t *testing.T) {
 	t.Log("output:\n" + out)
 
 	assertContains(t, out, "No changes on this branch.")
+}
+
+// TestDiff_UntrackedFiles verifies that wt diff includes untracked files.
+// Previously, untracked files caused "dirty" status but produced an empty diff.
+func TestDiff_UntrackedFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wt := env.addWorktree("diff-untracked")
+	os.WriteFile(filepath.Join(wt, "new-file.txt"), []byte("untracked content"), 0644)
+
+	out := env.wt("diff", "diff-untracked")
+	t.Log("output:\n" + out)
+
+	// Untracked file should appear in the diff output
+	assertContains(t, out, "new-file.txt")
+	assertContains(t, out, "untracked content")
+}
+
+// TestLs_DirtyFromUntracked verifies that a worktree with only untracked files
+// is classified as "dirty" and the diff is non-empty. This is the invariant:
+// dirty status implies a visible diff.
+func TestLs_DirtyFromUntracked(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+	t.Parallel()
+	env := newTestEnv(t)
+
+	wt := env.addWorktree("untracked-dirty")
+	os.WriteFile(filepath.Join(wt, "new.txt"), []byte("x"), 0644)
+
+	out := env.wt("ls")
+	t.Log("output:\n" + out)
+
+	assertContains(t, out, "untracked-dirty")
+	assertContains(t, out, "dirty")
+
+	// Diff must also be non-empty (the original bug: dirty but empty diff)
+	diffOut := env.wt("diff", "untracked-dirty")
+	assertContains(t, diffOut, "new.txt")
 }
 
 func TestDiff_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

- Untracked files now appear in `wt diff` output (previously invisible, causing "dirty but empty diff")
- Dirty classification is derived from the diff (`HasChanges`) instead of a separate `git status --porcelain` check — single source of truth eliminates the class of bugs where status and diff disagree
- `IsClean` removed; replaced by `HasChanges` (merge-base diff + untracked) and `HasUncommittedChanges` (safety check for merged-but-still-working case)
- Design doc updated to reflect the invariant: empty diff → cannot be dirty

## Invariant

```
!HasChanges → not dirty (guaranteed by structure)
HasChanges && unique == 0 → dirty (no commits explain the diff)
HasChanges && unique > 0 && merged && HasUncommitted → dirty (new work after merge)
HasChanges && unique > 0 && !merged → committed
```

## Tests added

- `TestDiff_UntrackedFiles` — untracked files appear in diff output
- `TestLs_DirtyFromUntracked` — untracked-only worktree classified as dirty with non-empty diff
- `TestLs_MergedButDirty` — squash-merged branch with new uncommitted work is dirty, not merged (data-loss protection)