### PR TITLE
Sort removable entries to the bottom of wt ls and wt rm output

### DIFF
--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -226,7 +226,8 @@ LLM or file), the full diff is printed directly with no color and no pager.
 
 List all worktrees with their status. Local worktrees (all repos under `$HOME`)
 and remote worktrees (all repos on the dev desktop) are discovered concurrently
-and merged into a single table sorted by most recent activity.
+and merged into a single table sorted by most recent activity, with removable
+entries (`*`) pushed to the bottom.
 
 Session metadata is fetched from the OpenCode server API, not from the database
 directly. For each server (local and remote), per worktree (parallel, bounded to

--- a/main.go
+++ b/main.go
@@ -220,7 +220,6 @@ func cmdLs() {
 	if enrichErr != nil {
 		die("%v", enrichErr)
 	}
-	worktree.Sort(all)
 
 	if len(all) == 0 {
 		fmt.Println("No worktrees found.")
@@ -236,6 +235,7 @@ func cmdLs() {
 			Status: statuses[i],
 		}
 	}
+	display.SortRows(rows)
 	display.PrintTable(rows, opencode.ServerPort())
 }
 

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -3,6 +3,7 @@ package display
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -23,6 +24,32 @@ var removableStatuses = map[string]bool{
 	"merged": true,
 	"stale":  true,
 	"empty":  true,
+}
+
+// SortRows sorts rows for display: removable statuses (*) sink to the bottom,
+// everything else sorts by most recent activity (UpdatedAt), newest first.
+func SortRows(rows []Row) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		ri, rj := removableStatuses[rows[i].Status], removableStatuses[rows[j].Status]
+		if ri != rj {
+			return rj // removable entries sink to bottom
+		}
+		ai, aj := rows[i].Entry.UpdatedAt, rows[j].Entry.UpdatedAt
+		if !ai.IsZero() && !aj.IsZero() {
+			return ai.After(aj)
+		}
+		if !ai.IsZero() {
+			return true
+		}
+		if !aj.IsZero() {
+			return false
+		}
+		ci, cj := rows[i].Entry.CreatedAt, rows[j].Entry.CreatedAt
+		if !ci.IsZero() && !cj.IsZero() {
+			return ci.After(cj)
+		}
+		return rows[i].Entry.Name < rows[j].Entry.Name
+	})
 }
 
 // PrintTable prints rows as an aligned table. Removable statuses get a * suffix.

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"path"
-	"sort"
 	"time"
 )
 
@@ -45,31 +44,6 @@ func GenerateName(project string) string {
 		panic("crypto/rand failed: " + err.Error())
 	}
 	return project + "-" + hex.EncodeToString(b[:])[:7]
-}
-
-// Sort sorts entries by most recent activity (UpdatedAt), newest first.
-// Entries without activity sort to the end, ordered by CreatedAt newest first.
-func Sort(entries []Entry) {
-	sort.SliceStable(entries, func(i, j int) bool {
-		ai := entries[i].UpdatedAt
-		aj := entries[j].UpdatedAt
-		// Both have activity — sort by most recent
-		if !ai.IsZero() && !aj.IsZero() {
-			return ai.After(aj)
-		}
-		// Only one has activity — it wins
-		if !ai.IsZero() {
-			return true
-		}
-		if !aj.IsZero() {
-			return false
-		}
-		// Neither has activity — sort by creation time
-		if !entries[i].CreatedAt.IsZero() && !entries[j].CreatedAt.IsZero() {
-			return entries[i].CreatedAt.After(entries[j].CreatedAt)
-		}
-		return entries[i].Name < entries[j].Name
-	})
 }
 
 // TimeUnix converts a unix timestamp to time.Time.

--- a/rm.go
+++ b/rm.go
@@ -254,12 +254,12 @@ type rmResult struct {
 	errMsg string
 }
 
-// sortRmResults sorts removed entries first, then by most recent activity.
+// sortRmResults sorts removed entries to the bottom, then by most recent activity.
 func sortRmResults(results []rmResult) {
 	sort.SliceStable(results, func(i, j int) bool {
 		ri, rj := results[i].status == "removed", results[j].status == "removed"
 		if ri != rj {
-			return ri
+			return rj // removed entries sink to bottom
 		}
 		ti, tj := results[i].entry.UpdatedAt, results[j].entry.UpdatedAt
 		if !ti.IsZero() && !tj.IsZero() {


### PR DESCRIPTION
## Summary

- Removable entries (`merged *`, `stale *`, `empty *`) now sort to the bottom of `wt ls`, keeping active work at the top.
- `wt rm` output similarly pushes removed entries to the bottom for a consistent experience.
- Sort logic moved from `worktree.Sort` (pre-classification) to `display.SortRows` (post-classification) so status is available for partitioning.