### PR TITLE
fix: set UTF-8 locale for remote tmux to fix Unicode rendering

### DIFF
--- a/pkg/transport/ssh.go
+++ b/pkg/transport/ssh.go
@@ -14,7 +14,10 @@ type SSH struct {
 func NewSSH(host string) *SSH { return &SSH{host: host} }
 
 func (s *SSH) Tmux(args ...string) (string, error) {
-	cmd := "tmux " + shellJoin(args)
+	// Non-interactive SSH doesn't source login profiles, so LANG is unset.
+	// If this command starts the tmux server, the server permanently inherits
+	// ASCII character-width tables, breaking all Unicode rendering in sessions.
+	cmd := "LANG=C.UTF-8 tmux " + shellJoin(args)
 	return ssh.Run(s.host, cmd)
 }
 


### PR DESCRIPTION
## Summary

- Non-interactive SSH has no locale set, so tmux servers started by `wt` default to ASCII character-width tables
- This breaks rendering of any Unicode characters (powerline glyphs, box-drawing, braille) inside the session
- Fix: prefix remote tmux commands with `LANG=C.UTF-8` so the tmux server starts with correct UTF-8 awareness

## Root Cause

When `wt` creates a remote session via `ssh host "tmux new-session -d ..."`, the SSH connection is non-interactive (no PTY, no login shell sourcing). `LANG` is unset. If this command starts the tmux server, the server's character-width tables are baked at startup with ASCII assumptions. Even attaching later with a proper locale doesn't fix the server-side rendering.

## Fix

One-line change in `pkg/transport/ssh.go` — prefix the tmux command with `LANG=C.UTF-8`:

```go
cmd := "LANG=C.UTF-8 tmux " + shellJoin(args)
```

This ensures the tmux server starts with UTF-8 character-width awareness without modifying any tmux settings or config files.