### PR TITLE
fix: set UTF-8 locale on tmux attach for client-side UTF-8 output

### DIFF
--- a/pkg/transport/ssh.go
+++ b/pkg/transport/ssh.go
@@ -22,9 +22,13 @@ func (s *SSH) Tmux(args ...string) (string, error) {
 }
 
 func (s *SSH) TmuxAttach(session string) error {
+	// LANG must be set for the client process too — tmux uses the attaching
+	// client's locale to decide whether to output UTF-8 to the terminal.
+	// Without it, the client inherits POSIX locale from sshd and tmux disables
+	// UTF-8 output, garbling all multi-byte characters on screen.
 	cmd := exec.Command("ssh", "-t",
 		"-o", "ControlPath="+ssh.ControlPath,
-		s.host, "tmux", "attach-session", "-t", session)
+		s.host, "LANG=C.UTF-8", "tmux", "attach-session", "-t", session)
 	return runInteractive(cmd)
 }
 


### PR DESCRIPTION
## Summary
- Set `LANG=C.UTF-8` in `TmuxAttach` SSH command so the tmux client process has `CLIENT_UTF8` set
- Without this, non-interactive SSH inherits POSIX locale from sshd, and tmux disables UTF-8 output to the terminal, garbling all multi-byte characters on screen
- The previous fix (#79) only covered server-side commands; this covers the client attach path