### PR TITLE
Add TOKENS column to wt ls showing total tokens consumed per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ its own branch. `wt` manages the lifecycle: create, list, resume, diff, clean up
 
 ```
 $ wt ls
-WORKTREE   STATUS      TITLE                              DIR                                              ACTIVITY  AGE
-a3f8c12    active      Rewrite Linux scheduler in Rust    ~/go/src/github.com/torvalds/linux-a3f8c12       now       3h
-b7e2a09    committed   Quantum-safe cryptography          ~/go/src/github.com/satoshi/bitcoin-b7e2a09      1d        1d
-e4f2a81    dirty       Finish The Winds of Winter         ~/go/src/github.com/grrm/asoiaf-e4f2a81          5m        15y
-e1d4b83    empty *     Autonomous drone delivery          ~/go/src/github.com/bezos/prime-air-e1d4b83      -         12y
-c9a1f57    merged *    Add exceptions to Go               ~/go/src/github.com/robpike/go-c9a1f57           2h        2h
-d5b8e24    stale *     Actually open OpenAI               ~/go/src/github.com/altman/openai-d5b8e24        4y        10y
-7f3b1c8    empty *     Half-Life 3                        ~/go/src/github.com/gaben/hl3-7f3b1c8            -         18y
+WORKTREE   STATUS      TITLE                              DIR                                              TOKENS  ACTIVITY  AGE
+a3f8c12    active      Rewrite Linux scheduler in Rust    ~/go/src/github.com/torvalds/linux-a3f8c12       1.2M    now       3h
+b7e2a09    committed   Quantum-safe cryptography          ~/go/src/github.com/satoshi/bitcoin-b7e2a09      450K    1d        1d
+e4f2a81    dirty       Finish The Winds of Winter         ~/go/src/github.com/grrm/asoiaf-e4f2a81          3.8M    5m        15y
+e1d4b83    empty *     Autonomous drone delivery          ~/go/src/github.com/bezos/prime-air-e1d4b83      -       -         12y
+c9a1f57    merged *    Add exceptions to Go               ~/go/src/github.com/robpike/go-c9a1f57           890K    2h        2h
+d5b8e24    stale *     Actually open OpenAI               ~/go/src/github.com/altman/openai-d5b8e24        72.1M   4y        10y
+7f3b1c8    empty *     Half-Life 3                        ~/go/src/github.com/gaben/hl3-7f3b1c8            -       -         18y
 ```
 
 ## Status

--- a/discover.go
+++ b/discover.go
@@ -75,6 +75,9 @@ func enrichAll(entries []worktree.Entry) {
 		if !info.Activity.IsZero() {
 			entries[i].UpdatedAt = info.Activity
 		}
+		if info.Tokens > 0 {
+			entries[i].Tokens = info.Tokens
+		}
 
 		// Check if agent process is running
 		if procs[dir] {

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -79,24 +79,27 @@ order:
 On create, the resolved command is saved to `wt.json`. On resume, the saved
 command is read from `wt.json`, falling back to `$WT_CMD` then `"opencode"`.
 
-### Title / Activity Detection
+### Title / Activity / Token Detection
 
-Title and activity are obtained by querying the agent's state store through a
-**provider** model. The provider is selected based on the `cmd` field in
-`wt.json`:
+Title, activity, and token counts are obtained by querying the agent's state
+store through a **provider** model. The provider is selected based on the `cmd`
+field in `wt.json`:
 
 - **OpenCode provider** — queries `~/.local/share/opencode/opencode.db` (or
   `~/Library/Application Support/opencode/opencode.db` on macOS) via the
   `sqlite3` CLI for the session's `title` and `time_updated` (stored as Unix
-  milliseconds). Falls back to scanning `.opencode/` directory entry mtimes in
-  the worktree if the database is unavailable.
+  milliseconds). Token counts are obtained by summing `$.tokens.total` from all
+  assistant messages in the session tree (recursive CTE traversing `parent_id`
+  to include subagent sessions). Falls back to scanning `.opencode/` directory
+  entry mtimes in the worktree if the database is unavailable (no token data in
+  fallback mode).
 - **Claude provider** — walks the `.claude/` directory tree in the worktree and
-  uses the most recent file mtime as the activity timestamp. No title is
-  available.
+  uses the most recent file mtime as the activity timestamp. No title or token
+  data is available.
 
 If `cmd` does not match a known provider, all providers are tried in order and
-the first non-empty result wins. If no provider returns data, the title column
-shows `"-"` and activity is empty.
+the first non-empty result wins. If no provider returns data, the title and
+tokens columns show `"-"` and activity is empty.
 
 ### Session Resume
 
@@ -133,12 +136,14 @@ queries `git worktree list --porcelain` in each, enriches with session data,
 classifies, sorts by activity (removable entries pushed to bottom).
 
 ```
-WORKTREE     STATUS      TITLE                   DIR                                   ACTIVITY  AGE
-api-a3f8c12  active      Implement OAuth flow    ~/go/src/github.com/ellistarn/api     3m        3h
-api-b7e2a09  committed   Fix rate limiting bug   ~/go/src/github.com/ellistarn/api     1h        1d
-wt-c9a1f57   dirty       Refactor DB layer       ~/go/src/github.com/ellistarn/wt      5m        2h
-wt-d5b8e24   merged *    -                       ~/go/src/github.com/ellistarn/wt      2d        2d
-wt-e1d4b83   empty *     -                       ~/go/src/github.com/ellistarn/wt      -         2d
+WORKTREE   STATUS      TITLE                              DIR                                              TOKENS  ACTIVITY  AGE
+a3f8c12    active      Rewrite Linux scheduler in Rust    ~/go/src/github.com/torvalds/linux-a3f8c12       1.2M    now       3h
+b7e2a09    committed   Quantum-safe cryptography          ~/go/src/github.com/satoshi/bitcoin-b7e2a09      450K    1d        1d
+e4f2a81    dirty       Finish The Winds of Winter         ~/go/src/github.com/grrm/asoiaf-e4f2a81          3.8M    5m        15y
+e1d4b83    empty *     Autonomous drone delivery          ~/go/src/github.com/bezos/prime-air-e1d4b83      -       -         12y
+c9a1f57    merged *    Add exceptions to Go               ~/go/src/github.com/robpike/go-c9a1f57           890K    2h        2h
+d5b8e24    stale *     Actually open OpenAI               ~/go/src/github.com/altman/openai-d5b8e24        72.1M   4y        10y
+7f3b1c8    empty *     Half-Life 3                        ~/go/src/github.com/gaben/hl3-7f3b1c8            -       -         18y
 ```
 
 ### `wt diff <name>`
@@ -237,7 +242,6 @@ worktree has a session, it is classified as merged.
 ## Scoped Out
 
 - Auto-cleanup on branch merge (requires polling or webhook).
-- Token/cost tracking per worktree.
 - Multiple discovery roots (only `$HOME` is scanned).
 
 ## Rejected Alternatives

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -60,7 +60,7 @@ func PrintTable(rows []Row) {
 		fmt.Println()
 	}
 	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tDIR\tACTIVITY\tAGE\n")
+	fmt.Fprintf(w, "WORKTREE\tSTATUS\tTITLE\tDIR\tTOKENS\tACTIVITY\tAGE\n")
 
 	now := time.Now()
 	for _, r := range rows {
@@ -76,7 +76,8 @@ func PrintTable(rows []Row) {
 		if title == "" {
 			title = "-"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, dir, activity, age)
+		tokens := formatTokens(e.Tokens)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, dir, tokens, activity, age)
 	}
 
 	w.Flush()
@@ -88,6 +89,21 @@ func formatActivity(updatedAt time.Time, now time.Time) string {
 		return "-"
 	}
 	return formatDuration(updatedAt, now)
+}
+
+// formatTokens returns a compact token count string (e.g. "1.2M", "450K", "8K").
+func formatTokens(tokens int64) string {
+	if tokens == 0 {
+		return "-"
+	}
+	switch {
+	case tokens >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(tokens)/1_000_000)
+	case tokens >= 1_000:
+		return fmt.Sprintf("%dK", tokens/1_000)
+	default:
+		return fmt.Sprintf("%d", tokens)
+	}
 }
 
 // formatDuration returns a compact relative time string.

--- a/pkg/provider/opencode.go
+++ b/pkg/provider/opencode.go
@@ -26,11 +26,25 @@ func queryOpenCodeDB(dir string) SessionInfo {
 		return SessionInfo{}
 	}
 
-	// Query for the most recent session in this directory.
-	// time_updated is a Unix timestamp (seconds).
-	query := `SELECT title, time_updated FROM session WHERE directory = '` + escapeSQLite(dir) + `' ORDER BY time_updated DESC LIMIT 1;`
+	// Single query: get title, activity, and total tokens (including subagents)
+	// for the most recent session in this directory. The recursive CTE traverses
+	// parent_id to include subagent sessions in the token sum.
+	query := `
+WITH RECURSIVE session_tree(id) AS (
+    SELECT id FROM session
+    WHERE id = (SELECT id FROM session WHERE directory = '` + escapeSQLite(dir) + `' ORDER BY time_updated DESC LIMIT 1)
+    UNION ALL
+    SELECT s.id FROM session s JOIN session_tree st ON s.parent_id = st.id
+)
+SELECT
+    (SELECT title FROM session WHERE id = (SELECT id FROM session_tree LIMIT 1)),
+    (SELECT time_updated FROM session WHERE id = (SELECT id FROM session_tree LIMIT 1)),
+    COALESCE(SUM(json_extract(m.data, '$.tokens.total')), 0)
+FROM message m
+WHERE m.session_id IN (SELECT id FROM session_tree)
+AND json_extract(m.data, '$.tokens.total') IS NOT NULL;`
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "sqlite3", "-separator", "\t", dbPath, query).Output()
 	if err != nil {
@@ -42,21 +56,31 @@ func queryOpenCodeDB(dir string) SessionInfo {
 		return SessionInfo{}
 	}
 
-	parts := strings.SplitN(line, "\t", 2)
-	if len(parts) < 2 {
+	parts := strings.SplitN(line, "\t", 3)
+	if len(parts) < 3 {
 		return SessionInfo{}
 	}
 
 	title := parts[0]
 
-	ts, err := strconv.ParseInt(parts[1], 10, 64)
-	if err != nil {
-		return SessionInfo{Title: title}
+	var activity time.Time
+	if ts, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
+		activity = time.UnixMilli(ts)
+	}
+
+	var tokens int64
+	if v, err := strconv.ParseInt(parts[2], 10, 64); err == nil {
+		tokens = v
+	}
+
+	if title == "" && activity.IsZero() && tokens == 0 {
+		return SessionInfo{}
 	}
 
 	return SessionInfo{
 		Title:    title,
-		Activity: time.UnixMilli(ts),
+		Activity: activity,
+		Tokens:   tokens,
 	}
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -10,6 +10,7 @@ import (
 type SessionInfo struct {
 	Title    string
 	Activity time.Time // last update time of the session
+	Tokens   int64     // total tokens consumed (including subagents)
 }
 
 // Query returns session info for a worktree directory.

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -34,6 +34,7 @@ type Entry struct {
 	UpdatedAt time.Time // most recent activity timestamp from provider
 	Status    string    // "active" or "" (no active session)
 	Title     string    // from agent state store via provider
+	Tokens    int64     // total tokens consumed in session (including subagents)
 }
 
 // HasSession reports whether this worktree has an active or historical session.


### PR DESCRIPTION
## Summary

- Adds a TOKENS column (before ACTIVITY) to `wt ls` output showing total tokens consumed per session including subagents
- Queries the opencode SQLite DB using a recursive CTE that traverses `parent_id` to sum tokens across the full session tree
- Displays compact values (e.g. `1.2M`, `450K`, `8K`) for quick visibility into work performed per worktree
- Updates design doc to move token tracking from "Scoped Out" to documented feature