### PR TITLE
Fix token math: use cumulative MAX per session, show base (+sub)

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -78,6 +78,9 @@ func enrichAll(entries []worktree.Entry) {
 		if info.Tokens > 0 {
 			entries[i].Tokens = info.Tokens
 		}
+		if info.SubTokens > 0 {
+			entries[i].SubTokens = info.SubTokens
+		}
 
 		// Check if agent process is running
 		if procs[dir] {

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -88,9 +88,11 @@ field in `wt.json`:
 - **OpenCode provider** — queries `~/.local/share/opencode/opencode.db` (or
   `~/Library/Application Support/opencode/opencode.db` on macOS) via the
   `sqlite3` CLI for the session's `title` and `time_updated` (stored as Unix
-  milliseconds). Token counts are obtained by summing `$.tokens.total` from all
-  assistant messages in the session tree (recursive CTE traversing `parent_id`
-  to include subagent sessions). Falls back to scanning `.opencode/` directory
+  milliseconds). Token counts use the MAX of `$.tokens.total` per session
+  (the value is cumulative within a session). The base session and subagent
+  sessions are reported separately: the display shows `base (+sub)` where sub
+  is the SUM of MAX values across all child sessions (recursive CTE traversing
+  `parent_id`). Falls back to scanning `.opencode/` directory
   entry mtimes in the worktree if the database is unavailable (no token data in
   fallback mode).
 - **Claude provider** — walks the `.claude/` directory tree in the worktree and

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -76,7 +76,7 @@ func PrintTable(rows []Row) {
 		if title == "" {
 			title = "-"
 		}
-		tokens := formatTokens(e.Tokens)
+		tokens := formatTokens(e.Tokens, e.SubTokens)
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, status, title, dir, tokens, activity, age)
 	}
 
@@ -91,11 +91,20 @@ func formatActivity(updatedAt time.Time, now time.Time) string {
 	return formatDuration(updatedAt, now)
 }
 
-// formatTokens returns a compact token count string (e.g. "1.2M", "450K", "8K").
-func formatTokens(tokens int64) string {
-	if tokens == 0 {
+// formatTokens returns a compact token count string (e.g. "35K (+35K)", "450K", "8K").
+func formatTokens(tokens, subTokens int64) string {
+	if tokens == 0 && subTokens == 0 {
 		return "-"
 	}
+	base := formatTokenCount(tokens)
+	if subTokens == 0 {
+		return base
+	}
+	return base + " (+" + formatTokenCount(subTokens) + ")"
+}
+
+// formatTokenCount formats a single token count compactly.
+func formatTokenCount(tokens int64) string {
 	switch {
 	case tokens >= 1_000_000:
 		return fmt.Sprintf("%.1fM", float64(tokens)/1_000_000)

--- a/pkg/provider/opencode.go
+++ b/pkg/provider/opencode.go
@@ -26,23 +26,29 @@ func queryOpenCodeDB(dir string) SessionInfo {
 		return SessionInfo{}
 	}
 
-	// Single query: get title, activity, and total tokens (including subagents)
-	// for the most recent session in this directory. The recursive CTE traverses
-	// parent_id to include subagent sessions in the token sum.
+	// Single query: get title, activity, and tokens split into base session vs
+	// subagents. The recursive CTE traverses parent_id to find subagent sessions.
+	// Tokens use MAX per session (the value is cumulative within a session).
 	query := `
-WITH RECURSIVE session_tree(id) AS (
-    SELECT id FROM session
+WITH RECURSIVE session_tree(id, depth) AS (
+    SELECT id, 0 FROM session
     WHERE id = (SELECT id FROM session WHERE directory = '` + escapeSQLite(dir) + `' ORDER BY time_updated DESC LIMIT 1)
     UNION ALL
-    SELECT s.id FROM session s JOIN session_tree st ON s.parent_id = st.id
+    SELECT s.id, st.depth + 1 FROM session s JOIN session_tree st ON s.parent_id = st.id
 )
 SELECT
     (SELECT title FROM session WHERE id = (SELECT id FROM session_tree LIMIT 1)),
     (SELECT time_updated FROM session WHERE id = (SELECT id FROM session_tree LIMIT 1)),
-    COALESCE(SUM(json_extract(m.data, '$.tokens.total')), 0)
-FROM message m
-WHERE m.session_id IN (SELECT id FROM session_tree)
-AND json_extract(m.data, '$.tokens.total') IS NOT NULL;`
+    COALESCE((SELECT MAX(json_extract(m.data, '$.tokens.total'))
+        FROM message m WHERE m.session_id = (SELECT id FROM session_tree WHERE depth = 0)
+        AND json_extract(m.data, '$.tokens.total') IS NOT NULL), 0),
+    COALESCE((SELECT SUM(session_max) FROM (
+        SELECT MAX(json_extract(m.data, '$.tokens.total')) AS session_max
+        FROM message m
+        WHERE m.session_id IN (SELECT id FROM session_tree WHERE depth > 0)
+        AND json_extract(m.data, '$.tokens.total') IS NOT NULL
+        GROUP BY m.session_id
+    )), 0);`
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -56,8 +62,8 @@ AND json_extract(m.data, '$.tokens.total') IS NOT NULL;`
 		return SessionInfo{}
 	}
 
-	parts := strings.SplitN(line, "\t", 3)
-	if len(parts) < 3 {
+	parts := strings.SplitN(line, "\t", 4)
+	if len(parts) < 4 {
 		return SessionInfo{}
 	}
 
@@ -73,14 +79,20 @@ AND json_extract(m.data, '$.tokens.total') IS NOT NULL;`
 		tokens = v
 	}
 
-	if title == "" && activity.IsZero() && tokens == 0 {
+	var subTokens int64
+	if v, err := strconv.ParseInt(parts[3], 10, 64); err == nil {
+		subTokens = v
+	}
+
+	if title == "" && activity.IsZero() && tokens == 0 && subTokens == 0 {
 		return SessionInfo{}
 	}
 
 	return SessionInfo{
-		Title:    title,
-		Activity: activity,
-		Tokens:   tokens,
+		Title:     title,
+		Activity:  activity,
+		Tokens:    tokens,
+		SubTokens: subTokens,
 	}
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -8,9 +8,10 @@ import (
 
 // SessionInfo contains information about an agent session in a directory.
 type SessionInfo struct {
-	Title    string
-	Activity time.Time // last update time of the session
-	Tokens   int64     // total tokens consumed (including subagents)
+	Title     string
+	Activity  time.Time // last update time of the session
+	Tokens    int64     // tokens consumed in the base session
+	SubTokens int64     // tokens consumed across subagent sessions
 }
 
 // Query returns session info for a worktree directory.

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -34,7 +34,8 @@ type Entry struct {
 	UpdatedAt time.Time // most recent activity timestamp from provider
 	Status    string    // "active" or "" (no active session)
 	Title     string    // from agent state store via provider
-	Tokens    int64     // total tokens consumed in session (including subagents)
+	Tokens    int64     // tokens consumed in the base session
+	SubTokens int64     // tokens consumed across subagent sessions
 }
 
 // HasSession reports whether this worktree has an active or historical session.


### PR DESCRIPTION
## Summary

- Fix token calculation: `$.tokens.total` is cumulative within a session, so the query now takes MAX per session instead of SUM across all messages (which was re-counting the growing context window on every exchange)
- Split token display into `base (+sub)` so the base number matches what OpenCode shows and subagent usage is visible separately