### PR TITLE
fix: session detection via CLI-first provider with symlink resolution

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -52,10 +52,12 @@ func enrichAll(entries []worktree.Entry) {
 	}
 	procs := findAgentProcesses()
 
+	// Batch-fetch all OpenCode sessions with one CLI call.
+	ocSessions := provider.FetchOpenCodeSessions()
+
 	for i := range entries {
 		dir := entries[i].Dir
 
-		// Query provider for title and activity
 		meta := worktree.ReadMetadata(entries[i].Repo, entries[i].Name)
 		cmd := meta.Cmd
 		if cmd == "" {
@@ -65,7 +67,22 @@ func enrichAll(entries []worktree.Entry) {
 			cmd = "opencode"
 		}
 
-		info := provider.Query(dir, cmd)
+		// Match session: CLI-first for opencode, mtime for claude.
+		var info provider.SessionInfo
+		if provider.BaseCmd(cmd) != "claude" {
+			info = ocSessions.Match(dir)
+			if info != (provider.SessionInfo{}) {
+				provider.EnrichTokens(dir, &info)
+			}
+		}
+		if info == (provider.SessionInfo{}) {
+			switch provider.BaseCmd(cmd) {
+			case "opencode":
+				info = provider.QueryOpenCodeDir(dir)
+			default:
+				info = provider.QueryClaude(dir)
+			}
+		}
 
 		if info.Title != "" {
 			entries[i].Title = info.Title

--- a/docs/designs/wt.md
+++ b/docs/designs/wt.md
@@ -85,16 +85,20 @@ Title, activity, and token counts are obtained by querying the agent's state
 store through a **provider** model. The provider is selected based on the `cmd`
 field in `wt.json`:
 
-- **OpenCode provider** — queries `~/.local/share/opencode/opencode.db` (or
-  `~/Library/Application Support/opencode/opencode.db` on macOS) via the
-  `sqlite3` CLI for the session's `title` and `time_updated` (stored as Unix
-  milliseconds). Token counts use the MAX of `$.tokens.total` per session
-  (the value is cumulative within a session). The base session and subagent
-  sessions are reported separately: the display shows `base (+sub)` where sub
-  is the SUM of MAX values across all child sessions (recursive CTE traversing
-  `parent_id`). Falls back to scanning `.opencode/` directory
-  entry mtimes in the worktree if the database is unavailable (no token data in
-  fallback mode).
+- **OpenCode provider** — CLI-first architecture. One call to
+  `opencode session list --format json` fetches all sessions with their `title`,
+  `updated` timestamp (Unix milliseconds), and `directory`. This batch result is
+  indexed by canonical (symlink-resolved) directory and matched against worktree
+  paths. Token counts are enriched separately via direct `sqlite3` queries
+  against the OpenCode database (`$XDG_DATA_HOME/opencode/opencode.db`,
+  `~/.local/share/opencode/opencode.db`, or
+  `~/Library/Application Support/opencode/opencode.db` on macOS). Token queries
+  use MAX of `$.tokens.total` per session (the value is cumulative); base and
+  subagent sessions are reported separately via a recursive CTE traversing
+  `parent_id`. If the CLI is unavailable, falls back to scanning `.opencode/`
+  directory entry mtimes in the worktree (no title or token data in fallback
+  mode). If `sqlite3` or the database is unavailable, title and activity still
+  display correctly — only the token column degrades to `"-"`.
 - **Claude provider** — walks the `.claude/` directory tree in the worktree and
   uses the most recent file mtime as the activity timestamp. No title or token
   data is available.
@@ -103,24 +107,33 @@ If `cmd` does not match a known provider, all providers are tried in order and
 the first non-empty result wins. If no provider returns data, the title and
 tokens columns show `"-"` and activity is empty.
 
+All directory comparisons resolve symlinks via `filepath.EvalSymlinks` to produce
+canonical paths. This handles systems with home directory symlinks (e.g.,
+`/home/user` → `/local/home/user` on NFS-backed dev desktops) where the CLI,
+database, and git may report different path representations for the same
+directory.
+
 ### Session Resume
 
 On resume, `wt` identifies the previous session to continue:
 
 - **OpenCode** — runs `opencode session list --format json` in the worktree
   directory, filters for the first entry whose `directory` field matches the
-  worktree path, and passes `--session <id>` to the agent command. This ensures
-  the correct session is resumed even when multiple worktrees share a project.
+  worktree path (both sides symlink-resolved), and passes `--session <id>` to
+  the agent command. This ensures the correct session is resumed even when
+  multiple worktrees share a project.
 - **Claude** — no explicit binding needed; Claude Code auto-resumes by
   directory.
 
 If no session is found, the agent starts a fresh session (correct for
 first-time use or after session deletion).
 
-The CLI is used here rather than direct sqlite3 queries (as in Title/Activity
-Detection) because it correctly handles project initialization on first access.
-Direct DB queries are used for `wt ls` because that path must be read-only and
-parallel across many worktrees.
+The CLI is the primary data source for both `wt ls` and resume. One
+`opencode session list` call returns all sessions — this is both faster (one
+process spawn vs N `sqlite3` invocations) and more reliable (the CLI handles
+its own path normalization, avoiding symlink mismatches in SQL queries). Direct
+`sqlite3` queries are used only for token enrichment because the CLI does not
+expose token counts.
 
 ### Process Detection
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,6 +12,7 @@ import (
 
 	"github.com/ellistarn/wt/pkg/display"
 	"github.com/ellistarn/wt/pkg/git"
+	"github.com/ellistarn/wt/pkg/provider"
 	"github.com/ellistarn/wt/pkg/worktree"
 )
 
@@ -322,32 +321,8 @@ func isOpenCodeCmd(cmd string) bool {
 	return filepath.Base(parts[0]) == "opencode"
 }
 
-// findOpenCodeSessionID uses the opencode CLI to find the most recent session
-// for the given directory. Returns "" if no session is found or the CLI fails.
+// findOpenCodeSessionID returns the most recent OpenCode session ID for the
+// given directory, or "" if no session is found.
 func findOpenCodeSessionID(dir string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "opencode", "session", "list", "--format", "json")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	var sessions []struct {
-		ID        string `json:"id"`
-		Directory string `json:"directory"`
-	}
-	if err := json.Unmarshal(out, &sessions); err != nil {
-		return ""
-	}
-
-	cleanDir := filepath.Clean(dir)
-	for _, s := range sessions {
-		if filepath.Clean(s.Directory) == cleanDir {
-			return s.ID
-		}
-	}
-	return ""
+	return provider.FetchOpenCodeSessions().MatchID(dir)
 }

--- a/pkg/provider/claude.go
+++ b/pkg/provider/claude.go
@@ -6,7 +6,9 @@ import (
 	"time"
 )
 
-func queryClaude(dir string) SessionInfo {
+// QueryClaude checks for a .claude/ directory in the worktree and uses
+// the most recent file mtime as activity indicator.
+func QueryClaude(dir string) SessionInfo {
 	// Check for .claude/ directory in the worktree itself.
 	// Use most recent file mtime as activity indicator.
 	claudeDir := filepath.Join(dir, ".claude")

--- a/pkg/provider/opencode.go
+++ b/pkg/provider/opencode.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,25 +11,71 @@ import (
 	"time"
 )
 
-func queryOpenCode(dir string) SessionInfo {
-	// Try SQLite database first (primary source of truth)
-	if info := queryOpenCodeDB(dir); info != (SessionInfo{}) {
-		return info
+// FetchOpenCodeSessions calls `opencode session list` once and returns all
+// sessions indexed by canonical directory. This is the primary data source
+// for title and activity — it avoids DB path discovery and SQL path-matching
+// issues entirely.
+func FetchOpenCodeSessions() SessionMap {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "opencode", "session", "list", "--format", "json").Output()
+	if err != nil {
+		return nil
 	}
 
-	// Fallback: check for .opencode/ directory in the worktree
-	return queryOpenCodeDir(dir)
+	var sessions []struct {
+		ID        string `json:"id"`
+		Title     string `json:"title"`
+		Updated   int64  `json:"updated"`
+		Directory string `json:"directory"`
+	}
+	if err := json.Unmarshal(out, &sessions); err != nil {
+		return nil
+	}
+
+	// Index by canonical directory. Sessions are returned most-recent-first,
+	// so the first match per directory wins.
+	result := make(SessionMap, len(sessions))
+	for _, s := range sessions {
+		canonical := resolveDir(s.Directory)
+		if _, exists := result[canonical]; exists {
+			continue // keep the most recent (first in list)
+		}
+		var activity time.Time
+		if s.Updated > 0 {
+			activity = time.UnixMilli(s.Updated)
+		}
+		result[canonical] = SessionInfo{
+			ID:       s.ID,
+			Title:    s.Title,
+			Activity: activity,
+		}
+	}
+	return result
 }
 
-func queryOpenCodeDB(dir string) SessionInfo {
+// EnrichTokens adds token data from the OpenCode SQLite database to an
+// existing SessionInfo. This is optional enrichment — if the DB is
+// unavailable or sqlite3 is not installed, the SessionInfo is unchanged.
+func EnrichTokens(dir string, info *SessionInfo) {
 	dbPath := openCodeDBPath()
 	if dbPath == "" {
-		return SessionInfo{}
+		return
 	}
 
-	// Single query: get title, activity, and tokens split into base session vs
-	// subagents. The recursive CTE traverses parent_id to find subagent sessions.
-	// Tokens use MAX per session (the value is cumulative within a session).
+	canonical := resolveDir(dir)
+	tokens, subTokens := queryTokens(dbPath, canonical)
+	if tokens > 0 {
+		info.Tokens = tokens
+	}
+	if subTokens > 0 {
+		info.SubTokens = subTokens
+	}
+}
+
+// queryTokens queries the DB for token counts only.
+func queryTokens(dbPath, dir string) (tokens, subTokens int64) {
 	query := `
 WITH RECURSIVE session_tree(id, depth) AS (
     SELECT id, 0 FROM session
@@ -37,8 +84,6 @@ WITH RECURSIVE session_tree(id, depth) AS (
     SELECT s.id, st.depth + 1 FROM session s JOIN session_tree st ON s.parent_id = st.id
 )
 SELECT
-    (SELECT title FROM session WHERE id = (SELECT id FROM session_tree LIMIT 1)),
-    (SELECT time_updated FROM session WHERE id = (SELECT id FROM session_tree LIMIT 1)),
     COALESCE((SELECT MAX(json_extract(m.data, '$.tokens.total'))
         FROM message m WHERE m.session_id = (SELECT id FROM session_tree WHERE depth = 0)
         AND json_extract(m.data, '$.tokens.total') IS NOT NULL), 0),
@@ -54,52 +99,32 @@ SELECT
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "sqlite3", "-separator", "\t", dbPath, query).Output()
 	if err != nil {
-		return SessionInfo{}
+		return 0, 0
 	}
 
 	line := strings.TrimSpace(string(out))
 	if line == "" {
-		return SessionInfo{}
+		return 0, 0
 	}
 
-	parts := strings.SplitN(line, "\t", 4)
-	if len(parts) < 4 {
-		return SessionInfo{}
+	parts := strings.SplitN(line, "\t", 2)
+	if len(parts) < 2 {
+		return 0, 0
 	}
 
-	title := parts[0]
-
-	var activity time.Time
-	if ts, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
-		activity = time.UnixMilli(ts)
-	}
-
-	var tokens int64
-	if v, err := strconv.ParseInt(parts[2], 10, 64); err == nil {
+	if v, err := strconv.ParseInt(parts[0], 10, 64); err == nil {
 		tokens = v
 	}
-
-	var subTokens int64
-	if v, err := strconv.ParseInt(parts[3], 10, 64); err == nil {
+	if v, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
 		subTokens = v
 	}
-
-	if title == "" && activity.IsZero() && tokens == 0 && subTokens == 0 {
-		return SessionInfo{}
-	}
-
-	return SessionInfo{
-		Title:     title,
-		Activity:  activity,
-		Tokens:    tokens,
-		SubTokens: subTokens,
-	}
+	return tokens, subTokens
 }
 
-// queryOpenCodeDir checks for a .opencode/ directory in the worktree and uses
-// the most recent file mtime as session activity. This serves as a fallback
-// when the SQLite database is unavailable.
-func queryOpenCodeDir(dir string) SessionInfo {
+// QueryOpenCodeDir checks for a .opencode/ directory in the worktree and uses
+// the most recent file mtime as session activity. This serves as a last-resort
+// fallback when both the CLI and database are unavailable.
+func QueryOpenCodeDir(dir string) SessionInfo {
 	ocDir := filepath.Join(dir, ".opencode")
 	if _, err := os.Stat(ocDir); err != nil {
 		return SessionInfo{}
@@ -135,7 +160,16 @@ func openCodeDBPath() string {
 		return ""
 	}
 
-	// Try ~/.local/share/opencode/opencode.db first (Linux / observed macOS location)
+	// Respect $XDG_DATA_HOME (defaults to ~/.local/share per XDG spec)
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome != "" {
+		path := filepath.Join(dataHome, "opencode", "opencode.db")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	// Try ~/.local/share/opencode/opencode.db (Linux default)
 	path := filepath.Join(home, ".local", "share", "opencode", "opencode.db")
 	if _, err := os.Stat(path); err == nil {
 		return path

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -8,34 +8,43 @@ import (
 
 // SessionInfo contains information about an agent session in a directory.
 type SessionInfo struct {
+	ID        string    // session identifier (for resume)
 	Title     string
 	Activity  time.Time // last update time of the session
 	Tokens    int64     // tokens consumed in the base session
 	SubTokens int64     // tokens consumed across subagent sessions
 }
 
-// Query returns session info for a worktree directory.
-// It tries providers based on the command name.
-// Returns zero SessionInfo if no provider matches or has data.
-func Query(dir, cmd string) SessionInfo {
-	switch baseCmd(cmd) {
-	case "opencode":
-		return queryOpenCode(dir)
-	case "claude":
-		return queryClaude(dir)
-	default:
-		// Try all providers, return first match
-		if info := queryOpenCode(dir); info != (SessionInfo{}) {
-			return info
-		}
-		return queryClaude(dir)
+// SessionMap holds sessions indexed by canonical (symlink-resolved) directory.
+type SessionMap map[string]SessionInfo
+
+// Match finds the session for a directory, resolving symlinks for comparison.
+func (m SessionMap) Match(dir string) SessionInfo {
+	if m == nil {
+		return SessionInfo{}
 	}
+	canonical := resolveDir(dir)
+	return m[canonical]
 }
 
-func baseCmd(cmd string) string {
+// MatchID returns the session ID for a directory, or "" if not found.
+func (m SessionMap) MatchID(dir string) string {
+	return m.Match(dir).ID
+}
+
+// BaseCmd extracts the base command name from a full command string.
+func BaseCmd(cmd string) string {
 	parts := strings.Fields(cmd)
 	if len(parts) == 0 {
 		return ""
 	}
 	return filepath.Base(parts[0])
+}
+
+// resolveDir returns the canonical path for a directory (symlinks resolved).
+func resolveDir(dir string) string {
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return resolved
+	}
+	return filepath.Clean(dir)
 }


### PR DESCRIPTION
## Summary

- Restructures the OpenCode provider to be CLI-first: one `opencode session list` call fetches all sessions (title, activity, ID), indexed by symlink-resolved directory
- SQLite DB is now only used for optional token enrichment (tokens column degrades gracefully if DB/sqlite3 unavailable)
- Fixes session detection on systems with home directory symlinks (e.g., `/home/user` → `/local/home/user` on NFS-backed dev desktops)
- Adds `$XDG_DATA_HOME` support for DB discovery
- Deduplicates session resume path (`findOpenCodeSessionID` delegates to `SessionMap.MatchID`)